### PR TITLE
Allow fetching trees with a slash in the tree name

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -71,7 +71,7 @@
       , root    = []
       , folders = { '': root }
 
-    api.getTree(repo.branch + '?recursive=true', function(err, tree) {
+    api.getTree(encodeURIComponent(repo.branch) + '?recursive=true', function(err, tree) {
       if (err) return done(err)
       tree.forEach(function(item) {
         var path   = item.path


### PR DESCRIPTION
Currently, a branch with a name like `release/1.0` will error (404 from Github API). This fixes the issue and allows the branch to be fetched.
