### PR TITLE
Fix text-overflow in Firefox.

### DIFF
--- a/inject.css
+++ b/inject.css
@@ -37,6 +37,7 @@ html.octotree {
     margin: 10px 5px;
     height: 20px;
     white-space: nowrap;
+    overflow: hidden;
     text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
text-overflow doesn't work in Firefox if we don't hide the overflow first.
