### PR TITLE
Add some more reserved names.

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -49,7 +49,24 @@
     if (!match) return false
 
     // must not be a reserved `username`
-    if (~['settings', 'organizations', 'site', 'blog'].indexOf(match[1])) return false
+    var RESERVED_USERNAMES = [
+      'settings',
+      'organizations',
+      'site',
+      'blog',
+      'about',
+      'orgs',
+      'styleguide',
+      'showcases',
+      'trending',
+      'stars',
+      'dashboard',
+      'notifications'
+    ];
+    var RESERVED_REPONAMES = ['followers', 'following'];
+     
+    if (~RESERVED_USERNAMES.indexOf(match[1])) return false
+    if (~RESERVED_REPONAMES.indexOf(match[2])) return false
 
     // TODO: the intention is to hide the sidebar when users navigate to non-code areas (e.g. Issues, Pulls)
     // and show it again when users navigate back to the code area


### PR DESCRIPTION
I just browsed around and noted down the non-code URLs where the sidebar popped up. There might be more I haven't noticed...

`about` is used for the about pages (e.g. github.com/about/team)
`orgs` is used when you view the dashboard for an organization you're in.
`styleguide` is e.g. https://github.com/styleguide/css/7.0
`showcases` and `trending` are used in the Explore feature
`stars` is used to see a user's stars (e.g. github.com/stars/:username)
`dashboard` is used for the personal dashboard
`notifications` is e.g. https://github.com/notifications/participating

There are some more (e.g. `watching`) but they don't seem to have subpaths so they don't match the regex anyway.

I also noticed that `followers` and `following` are reserved repo names (not sure why; I'd have expected e.g. github.com/followers/:username instead of github.com/:username/followers).
