### PR TITLE
Get tree correctly when it is with sha hash

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -92,7 +92,7 @@
     return { 
       username : match[1], 
       reponame : match[2],
-      branch   : $('*[data-master-branch]').data('ref') || 'master'
+      branch   : $('*[data-master-branch]').data('ref') || $('*[data-master-branch] > .js-select-button').text() || 'master'
     }
   }
 


### PR DESCRIPTION
For example, https://github.com/buunguyen/octotree/tree/2d46b30a7db6a5e03d0da81ff5c7c74b3e793805
