### PR TITLE
Update inject.css

### DIFF
--- a/src/inject.css
+++ b/src/inject.css
@@ -21,14 +21,18 @@ html.octotree {
     z-index: 999991;
     -webkit-transition: -webkit-transform 0.2s ease;
     transition: transform 0.2s ease;
-    -webkit-transform: translate3d(-100%, 0, 0);
-    transform: translate3d(-100%, 0, 0);
+    left: 250px;
+    padding: 50px 0 30px;
 }
 .octotree .octotree_sidebar {
-    -webkit-transform: translate3d(0, 0, 0);
-    transform: translate3d(0, 0, 0);
+    left:0;
 }
-
+.octotree_footer{
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
 .octotree_header {
     font-size: 16px;
     line-height: 2.7;
@@ -36,6 +40,9 @@ html.octotree {
     margin-bottom: 0;
     padding-left: 13px;
     width: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
 }
 
 .octotree_header_error {
@@ -74,6 +81,10 @@ html.octotree {
 }
 
 /* Source tree */
+.octotree_treeview{
+    height: 100%;
+    overflow: auto;
+}
 .octotree_treeview .jstree-icon.tree,
 .octotree_treeview .jstree-icon.blob {
     font: normal normal 16px octicons;


### PR DESCRIPTION
- Use css position to display sidebar instead of translate3d so we can
  move octotree_toggle inside octotree_sidebar. (Please help to update HTML)
- Fixed Repo name, only show scrollbar inside treeview
