### PR TITLE
Minor verbiage update for private repositories

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -34,7 +34,7 @@
                        '</div>' +
                        '<div>' +
                          '<button type="submit" class="button">Save</button>' +
-                         '<a href="https://github.com/buunguyen/octotree#github-api-rate-limit" target="_blank">Why need access token?</a>' +
+                         '<a href="https://github.com/buunguyen/octotree#github-api-rate-limit" target="_blank">Why is this required?</a>' +
                        '</div>' +
                        '<div class="error"/>' +
                      '</form>' +


### PR DESCRIPTION
Hi there,

I was just using Octotree on a private repository and thought the text `Why need access token?` might read better as `Why is this required?`. Patch attached for your consideration.

Cheers,
  Lee :beers:

![github_github](https://cloud.githubusercontent.com/assets/121322/3033425/17260692-e064-11e3-8ec6-2967abfc6496.png)
