### PR TITLE
Added a padding to the repo info in the header

### DIFF
--- a/src/main.less
+++ b/src/main.less
@@ -58,6 +58,10 @@
       margin: -5px 0 0;
       text-shadow: 0 1px 0 #fff;
       border-bottom: 1px solid #e5e5e5;
+      .octotree_header_repo {
+        // Make room for the buttons
+        padding-right: 60px;
+      }
     }
   }
 


### PR DESCRIPTION
Otherwise the buttons overlap the repo name.
