### PR TITLE
Adjust spacing to match new GitHub header

### DIFF
--- a/src/octotree.less
+++ b/src/octotree.less
@@ -4,7 +4,7 @@
 
 .octotree_sidebar {
   position: fixed !important;
-  padding-top: 41px;
+  padding-top: 52px;
   overflow: visible;
   top: 0;
   right: 0;
@@ -53,13 +53,13 @@
       position: absolute;
       top: 0;
       left: 0;
-      height: 46px;
+      height: 49px;
       font-size: 16px;
       line-height: 2.7;
       background-color: #f3f3f3;
       background-image: linear-gradient(#f9f9f9, #f3f3f3);
       background-repeat: repeat-x;
-      margin: -5px 0 0;
+      margin: 0;
       text-shadow: 0 1px 0 #fff;
       border-bottom: 1px solid #e5e5e5;
     }
@@ -227,7 +227,7 @@ a.octotree_toggle, a.octotree_opts {
 a.octotree_opts {
   width: 15px;
   height: 15px;
-  top: 13px;
+  top: 18px;
   right: 42px;
 
   & > span {
@@ -241,7 +241,7 @@ a.octotree_toggle {
   width: 30px;
   height: 30px;
   padding: 6px 6px !important;
-  top: 5px;
+  top: 10px;
   right: -35px;
 
   & > span {


### PR DESCRIPTION
A new GitHub header was shipped earlier today, so I adjusted the spacing and height of the Octotree header to match.

https://twitter.com/mdo/status/501895751316680706
