### PR TITLE
Handle ctrlkey clicking

### DIFF
--- a/src/view.tree.js
+++ b/src/view.tree.js
@@ -23,7 +23,7 @@ function TreeView($dom, store, adapter) {
           ? $target.children(':first')
           : $target.siblings(':first') // handles child links in submodule
 
-      if (event.ctrlKey) window.open(href)
+      if (event.ctrlKey || event.which === 2) window.open(href)
       else if ($icon.hasClass('commit')) adapter.selectSubmodule(href)
       else if ($icon.hasClass('blob')) adapter.selectPath(href)
     })


### PR DESCRIPTION
When holding the ctrlkey, a new window tab is expected. (I usually wanted to.)
But the lib jstree seems to cut the way from the origin (event.preventDefault).
So we had to detect and act on our side.
Any suggestions? Thanks!
