### PR TITLE
Add option to only load repo when sidebar is opened

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -5,6 +5,7 @@ const
     TOKEN    : 'octotree.github_access_token',
     COLLAPSE : 'octotree.collapse',
     REMEMBER : 'octotree.remember',
+    LAZYLOAD : 'octotree.lazyload',
     HOTKEYS  : 'octotree.hotkeys',
     GHEURLS  : 'octotree.gheurls',
     WIDTH    : 'octotree.sidebar_width',

--- a/src/template.html
+++ b/src/template.html
@@ -42,6 +42,9 @@
             <label><input type="checkbox" data-store="REMEMBER"> Show sidebar if previously shown</label>
           </div>
           <div>
+            <label><input type="checkbox" data-store="LAZYLOAD"> Only load tree when sidebar is open</label>
+          </div>
+          <div>
             <label><input type="checkbox" data-store="COLLAPSE"> Collapse folders with single sub-folder</label>
           </div>
           <!-- @ifdef CHROME -->


### PR DESCRIPTION
This is related to #80, and adds an option to only load the current repo when the sidebar is opened. It should work fine with the "remember" option as well, and automatically load if the sidebar was shown last.
