### PR TITLE
Fix exceptions caused by blob.content including `\n`

### DIFF
--- a/src/adapter.github.js
+++ b/src/adapter.github.js
@@ -185,7 +185,7 @@ GitHub.prototype.fetchData = function(opts, cb) {
   function getBlob(sha, cb) {
     get('/git/blobs/' + sha, function(err, res) {
       if (err) return cb(err)
-      cb(null, atob(res.content))
+      cb(null, atob(res.content.replace(/\n/g,'')))
     })
   }
 


### PR DESCRIPTION
octotree stopped in some repositories.
e.g.: https://github.com/ReactiveCocoa/ReactiveCocoa

Some blob returns base64 content including `\n`.
This cause exception in `atob()` and stop octotree.
The document does not mention about it.
https://developer.github.com/v3/git/blobs/#get-a-blob
