### PR TITLE
Branch switcher in header

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -126,16 +126,25 @@ class GitHub extends PjaxAdapter {
 
     // Still no luck, get default branch for real
     const repo = {username: username, reponame: reponame, branch: branch, pullNumber: pullNumber}
-    if (repo.branch) {
-      cb(null, repo)
-    }
-    else {
-      this._get(null, {repo, token}, (err, data) => {
-        if (err) return cb(err)
-        repo.branch = this._defaultBranch[username + '/' + reponame] = data.default_branch || 'master'
+
+    // Get all branches for branch switcher
+    this._get('/branches', {repo, token}, (err, data) => {
+      if (err) return cb(err);
+      repo.branches = data.map((repoBranch) => {
+        return repoBranch.name;
+      });
+
+      if (repo.branch) {
         cb(null, repo)
-      })
-    }
+      }
+      else {
+        this._get(null, {repo, token}, (err, data) => {
+          if (err) return cb(err)
+          repo.branch = this._defaultBranch[username + '/' + reponame] = data.default_branch || 'master'
+          cb(null, repo)
+        })
+      }
+    });
   }
 
   // @override

--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -126,25 +126,16 @@ class GitHub extends PjaxAdapter {
 
     // Still no luck, get default branch for real
     const repo = {username: username, reponame: reponame, branch: branch, pullNumber: pullNumber}
-
-    // Get all branches for branch switcher
-    this._get('/branches', {repo, token}, (err, data) => {
-      if (err) return cb(err);
-      repo.branches = data.map((repoBranch) => {
-        return repoBranch.name;
-      });
-
-      if (repo.branch) {
+    if (repo.branch) {
+      cb(null, repo)
+    }
+    else {
+      this._get(null, {repo, token}, (err, data) => {
+        if (err) return cb(err)
+        repo.branch = this._defaultBranch[username + '/' + reponame] = data.default_branch || 'master'
         cb(null, repo)
-      }
-      else {
-        this._get(null, {repo, token}, (err, data) => {
-          if (err) return cb(err)
-          repo.branch = this._defaultBranch[username + '/' + reponame] = data.default_branch || 'master'
-          cb(null, repo)
-        })
-      }
-    });
+      })
+    }
   }
 
   // @override

--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -38,7 +38,7 @@
       .octotree_view_header {
         font-weight: normal;
         text-shadow: none;
-        height: 54px;
+        height: 66px;
         line-height: 2.8;
         background: #fafbfc none;
         border-right: 1px solid #e1e4e8;

--- a/src/view.tree.js
+++ b/src/view.tree.js
@@ -52,28 +52,11 @@ class TreeView {
   _showHeader(repo) {
     const adapter = this.adapter
 
-    let currentBranchName = repo.branch.toString();
-    let branchHtml = '';
+    // Copy GitHub's branch switcher
+    let branchHtml = $('<div>').append($('.branch-select-menu').clone()).html();
 
-    // Display branch switcher if the repository has multiple branches
-    if (repo.branches && repo.branches.length > 1) {
-      branchHtml = '<select id="octotree_header_branch_switcher">' +
-        repo.branches.map((branchName) => {
-          const safeBranchName = this._deXss(branchName).toString();
-
-          // Disable non-matching branch names, because URL won't work
-          const disabled = branchName !== safeBranchName;
-          const selected = branchName === currentBranchName;
-
-          return '<option value="' + safeBranchName + '"' +
-            (disabled ? ' disabled' : '') +
-            (selected ? ' selected' : '') +
-            '>' + safeBranchName + '</option>'
-        }).join('') +
-      '</select>';
-    }
-    else {
-      branchHtml = this._deXss(currentBranchName);
+    if (branchHtml === null || branchHtml === '') {
+      branchHtml = this._deXss(repo.branch.toString());
     }
 
     this.$view.find('.octotree_view_header')
@@ -93,27 +76,6 @@ class TreeView {
         const newTab = event.shiftKey || event.ctrlKey || event.metaKey
         newTab ? adapter.openInNewTab(href) : adapter.selectFile(href)
       })
-      .on('change', '#octotree_header_branch_switcher', function () {
-        const currentPathWithBranch = repoPath + '/tree/' + currentBranchName;
-        const newBranchName = $(this).val();
-
-        let newPath = '';
-
-        /*
-         * If currently viewing a branch, replace the branch in the URL with
-         * the new branch name. This also handles viewing a file on a branch.
-         */
-        const indexOfBranch = window.location.pathname.indexOf(currentBranchName);
-        if (indexOfBranch > -1) {
-          newPath = window.location.pathname.replace(currentBranchName, newBranchName);
-        }
-        // Otherwise, navigate to the repository root of the new branch
-        else {
-          newPath = repoPath + '/tree/' + newBranchName;
-        }
-
-        adapter.selectSubmodule(newPath);
-      });
   }
 
   _deXss(str) {


### PR DESCRIPTION
### Description
Add a branch switcher to the header, if the repository has multiple branches. This addresses issue https://github.com/buunguyen/octotree/issues/317.

### Proposal
Allow users to switch between branches of the repository.

From the linked issue:
>Selecting a branch would load the related tree but not navigate until an item in the tree is clicked.

Instead of following this suggestion, this code will navigate immediately once a branch is selected, mimicking the behavior of GitHub's built-in branch dropdown.

### Demo

I created these branches in my fork of this repo:
- `master`
- `branch-switcher`
- `nonsense<branch&another`

I've since added branches with more 'special' characters ([my fork](https://github.com/ChaseWagoner/octotree)).

Here's a basic demo:

![branch-switcher](https://user-images.githubusercontent.com/3303680/31422338-ce7a62d4-ae01-11e7-984d-1e9912cde8cd.gif)

### Discussion (non-exhaustive list)
- I disabled switching to a branch when its `deXss`ed name doesn't match its raw name, because I don't know the complete list of characters GitHub allows/encodes in URLs, and I don't want to guess incorrectly.
- This doesn't work well when a file doesn't exist.
    - Example: [this file](https://github.com/ChaseWagoner/octotree/blob/temp/branch/extra-file.txt) exists only on one branch. Switching to another branch yields a 404.
    - In this case, fetching the new branch's tree would actually be pretty helpful.
- These changes are heavily GitHub-specific, and Bitbucket is completely disregarded. I opted into the Bitbucket "refreshed UI" and couldn't figure out how to opt out.
    - I'm happy to move as much logic into the GitHub adapter as possible, but at time of writing I'm turning in for the evening and want to get a round of feedback if possible.
- Should there be a branch filter as well? (Since I mentioned trying to match GitHub's functionality...)