### PR TITLE
Minor layout fixes

### DIFF
--- a/src/styles/base.less
+++ b/src/styles/base.less
@@ -45,6 +45,10 @@
       margin: 0;
       text-shadow: 0 1px 0 #fff;
       z-index: 1000002;
+      padding-right: 65px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
 
     .octotree_help {
@@ -60,7 +64,6 @@
     }
     .octotree_header_repo, .octotree_header_branch {
       width: 100%;
-      padding-right: 55px;
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;


### PR DESCRIPTION
On small screens I always try to minimize the size of the octotree column. This PR aim to fix some edge-case behaviors.
 
| Summary of what issue(s) this PR resolves | Summary of what changes this PR proposes
| -- | -- |
| <img width="273" alt="schermata 2018-02-08 alle 00 02 57 2" src="https://user-images.githubusercontent.com/6209647/35982806-f71ff5b6-0cf0-11e8-855a-4027a5ff8e15.png"> | <img width="272" alt="schermata 2018-02-08 alle 00 06 28 2" src="https://user-images.githubusercontent.com/6209647/35982836-0b03d3b8-0cf1-11e8-90fa-ec37d9e418cb.png"> |
<img width="266" alt="schermata 2018-02-08 alle 12 40 15 2" src="https://user-images.githubusercontent.com/6209647/35982819-fd9fe5f4-0cf0-11e8-9ea1-84447e46a668.png"> | <img width="266" alt="schermata 2018-02-08 alle 12 39 07 2" src="https://user-images.githubusercontent.com/6209647/35982893-2756af2c-0cf1-11e8-81c4-9e633005fbc8.png"> |

Tested on Firefox 58 and Chrome 64

