### PR TITLE
WIP: feat(toggle-show): toggle focus on show

### DIFF
--- a/src/octotree.js
+++ b/src/octotree.js
@@ -157,6 +157,7 @@ $(document).ready(() => {
     function toggleSidebarAndSave() {
       store.set(STORE.SHOWN, !isSidebarVisible(), () => {
         toggleSidebar()
+
         if (isSidebarVisible()) {
           tryLoadRepo()
         }
@@ -171,6 +172,13 @@ $(document).ready(() => {
       else {
         $html.toggleClass(SHOW_CLASS)
         $document.trigger(EVENT.TOGGLE, isSidebarVisible())
+        // when showing the tree, give it focus ELSE blur
+        if (isSidebarVisible()) {
+          treeView.$jstree.get_container().focus()
+          treeView.syncSelection()
+        } else {
+          treeView.$jstree.get_container().blur()
+        }
       }
     }
 


### PR DESCRIPTION
### Description
when toggling hide/show of the octotree explorer the users cursor focus doesnt change

### Proposal
when toggling hide/show of the octotree explorer the users cursor focuses into the tree on show and blurs on hide
