### PR TITLE
Update GitHub repo parser to handle browsing repo at commit. Fixes #473.

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -118,14 +118,14 @@ class GitHub extends PjaxAdapter {
     const pullNumber = isPR && showOnlyChangedInPR ? typeId : null
 
     // Skip non-code page unless showInNonCodePage is true
-    if (!showInNonCodePage && type && !~['tree', 'blob', 'commit'].indexOf(type)) {
+    const isCodePage = ['tree', 'blob', 'commit'].indexOf(type) >= 0
+    if (!showInNonCodePage && type && !isCodePage) {
       return cb()
     }
 
-    const isBranchOrSha = ['tree', 'blob', 'commit'].indexOf(type) >= 0 && typeId
-    const branchOrSha = isBranchOrSha && typeId ? typeId : null
-
     // Get branch by inspecting page, quite fragile so provide multiple fallbacks
+    const isBranchOrSha = isCodePage && typeId
+    const branchOrSha = isBranchOrSha && typeId ? typeId : null
     const branch =
       // Branch/Tag/Commit from URL
       branchOrSha ||

--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -118,12 +118,17 @@ class GitHub extends PjaxAdapter {
     const pullNumber = isPR && showOnlyChangedInPR ? typeId : null
 
     // Skip non-code page unless showInNonCodePage is true
-    if (!showInNonCodePage && type && !~['tree', 'blob'].indexOf(type)) {
+    if (!showInNonCodePage && type && !~['tree', 'blob', 'commit'].indexOf(type)) {
       return cb()
     }
 
+    const isBranchOrSha = ['tree', 'blob', 'commit'].indexOf(type) >= 0 && typeId
+    const branchOrSha = isBranchOrSha && typeId ? typeId : null
+
     // Get branch by inspecting page, quite fragile so provide multiple fallbacks
     const branch =
+      // Branch/Tag/Commit from URL
+      branchOrSha ||
       // Code page
       $('.branch-select-menu .select-menu-item.selected').data('name') ||
       // Pull requests page

--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -118,17 +118,15 @@ class GitHub extends PjaxAdapter {
     const pullNumber = isPR && showOnlyChangedInPR ? typeId : null
 
     // Skip non-code page unless showInNonCodePage is true
-    const isCodePage = ['tree', 'blob', 'commit'].indexOf(type) >= 0
-    if (!showInNonCodePage && type && !isCodePage) {
+    const isCodePage = !type || ['tree', 'blob', 'commit'].indexOf(type) >= 0
+    if (!showInNonCodePage && !isCodePage) {
       return cb()
     }
 
     // Get branch by inspecting page, quite fragile so provide multiple fallbacks
-    const isBranchOrSha = isCodePage && typeId
-    const branchOrSha = isBranchOrSha && typeId ? typeId : null
     const branch =
-      // Branch/Tag/Commit from URL
-      branchOrSha ||
+      // Branch/tag/commit from URL
+      (isCodePage && typeId) ||
       // Code page
       $('.branch-select-menu .select-menu-item.selected').data('name') ||
       // Pull requests page


### PR DESCRIPTION
### Problem
This addresses #473, where Octotree was not handling viewing the repo at commit level properly. In that case, it was not finding any branch or commit info, and falling back to `master`, and showing repo contents and links based on `master` instead of at the current commit.

### Solution
This solution makes use of the fact that GitHub URL structure and API endpoints treat branches, labels, and sha commit references equivalently. The code now recognizes the commit sha from the URL and uses it as the branch. Therefore the sha is displayed in Octotree, used for the repo API call, and is present in all links generated.

### Screenshots
This shows Octotree showing a repo at a commit:
<img width="279" alt="screen shot 2018-10-15 at 12 09 50 am" src="https://user-images.githubusercontent.com/6874678/46931235-ec290c00-d00f-11e8-8763-830309dbc1bf.png">
