### PR TITLE
Fix: get 404 when branch name has slash

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -146,12 +146,15 @@ class GitHub extends PjaxAdapter {
       return cb();
     }
 
+    const branchOnMenu = $('.branch-select-menu .select-menu-item.selected').data('name') || '';
+
     // Get branch by inspecting URL or DOM, quite fragile so provide multiple fallbacks
     const branch =
       // Branch/tag/commit from URL
-      (isCodePage && typeId) ||
+      // Exclude edge case: branch name has slash '/'
+      (!branchOnMenu.includes('/') && isCodePage && typeId) ||
       // Code page
-      $('.branch-select-menu .select-menu-item.selected').data('name') ||
+      branchOnMenu ||
       // Pull requests page
       ($('.commit-ref.base-ref').attr('title') || ':').match(/:(.*)/)[1] ||
       // Reuse last selected branch if exist

--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -146,15 +146,12 @@ class GitHub extends PjaxAdapter {
       return cb();
     }
 
-    const branchOnMenu = $('.branch-select-menu .select-menu-item.selected').data('name') || '';
-
     // Get branch by inspecting URL or DOM, quite fragile so provide multiple fallbacks
     const branch =
-      // Branch/tag/commit from URL
-      // Exclude edge case: branch name has slash '/'
-      (!branchOnMenu.includes('/') && isCodePage && typeId) ||
+      // Code page with commit ID
+      (isCodePage && typeId && typeId.match(/[a-z, 0-9]{40}/)) ||
       // Code page
-      branchOnMenu ||
+      $('.branch-select-menu .select-menu-item.selected').data('name') ||
       // Pull requests page
       ($('.commit-ref.base-ref').attr('title') || ':').match(/:(.*)/)[1] ||
       // Reuse last selected branch if exist


### PR DESCRIPTION
Suggest another solution for the issue [#559](https://github.com/ovity/octotree/issues/559)

a @duylam , Could you check if I might miss any case ?

Many thanks. 