### PR TITLE
Feature: Sidebar v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ By default, Octotree only works on `github.com`. To support enterprise version (
 
 ### Others
 * __Hotkeys__: Octotree uses [keymaster](https://github.com/madrobby/keymaster) to register hotkeys. Check out the [supported keys](https://github.com/madrobby/keymaster#supported-keys).
-* __Remember sidebar visibility__: if checked, show or hide Octotree based on its last visibility.
 * __Show in non-code pages__: if checked, allow Octotree to show in non-code pages such as Issues and Pull Requests.
 * __Load entire tree at once__: if checked, load and render the entire code tree at once. To avoid long loading, this should be unchecked if you frequently work with very large repos.
 * __Show only pull request changes__ _(new!)_: if checked and in "Pull requests" page, only show the change set of the pull request.

--- a/src/adapters/adapter.js
+++ b/src/adapters/adapter.js
@@ -295,7 +295,7 @@ class Adapter {
    * Updates the layout based on sidebar visibility and width.
    * @api public
    */
-  updateLayout(togglerVisible, sidebarVisible, sidebarWidth) {
+  updateLayout(sidebarPinned, sidebarVisible, sidebarWidth) {
     throw new Error('Not implemented');
   }
 

--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -86,23 +86,17 @@ class GitHub extends PjaxAdapter {
   }
 
   // @override
-  updateLayout(togglerVisible, sidebarVisible, sidebarWidth) {
+  updateLayout(sidebarPinned, sidebarVisible, sidebarWidth) {
     const SPACING = 10;
     const $header = $(GH_HEADER);
     const $containers = $(GH_CONTAINERS);
     const autoMarginLeft = ($(document).width() - $containers.width()) / 2;
-    const shouldPushEverything = sidebarVisible && autoMarginLeft <= sidebarWidth + SPACING;
+    const shouldPushEverything = sidebarPinned && sidebarVisible;
+    const smallScreen = autoMarginLeft <= sidebarWidth + SPACING;
 
-    $('html').css('margin-left', shouldPushEverything ? sidebarWidth : '');
-    $containers.css('margin-left', shouldPushEverything ? SPACING : '');
-
-    const headerPadding =
-      shouldPushEverything || (!togglerVisible && !sidebarVisible)
-        ? '' // Nothing is visible or already pushed, leave as-is
-        : !sidebarVisible
-          ? 25 // Sidebar is collapsed, move the logo to avoid hiding the toggler
-          : sidebarWidth; // Otherwise, move the header from the sidebar
-    $header.css('padding-left', headerPadding);
+    $('html').css('margin-left', shouldPushEverything && smallScreen ? sidebarWidth : '');
+    $containers.css('margin-left', shouldPushEverything && smallScreen ? SPACING : '');
+    $header.css('padding-left', shouldPushEverything && !smallScreen ? sidebarWidth : '');
   }
 
   // @override

--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -5,13 +5,38 @@
 
   .octotree_github_sidebar {
     a.octotree_toggle {
-      right: 12px;
-      top: 14px;
+      visibility: hidden;
+    }
 
-      &:not(.octotree_loading) > span:after,
-      &:not(.octotree_loading):hover > span:after {
-        #octicons.chevron-left();
-        font-size: 15px;
+    a.octotree_spin {
+      right: 12px;
+      top: 65px;
+      &.octotree_loading {
+        & > span:after {
+          content: '';
+        }
+
+        .loader {
+          border-radius: 50%;
+          border: 2px solid #000;
+          border-top: 2px solid rgba(0, 0, 0, 0);
+          border-left: 2px solid rgba(0, 0, 0, 0);
+          width: 16px;
+          height: 16px;
+          animation: loading 0.5s infinite linear;
+        }
+      }
+        @keyframes loading {
+        0% {
+          transform: rotate(0deg);
+        }
+        100% {
+          transform: rotate(360deg);
+        }
+      }
+
+      &:not(.octotree_loading) {
+        visibility: hidden;
       }
     }
   }
@@ -159,7 +184,7 @@
 
   a.octotree_opts {
     top: 21px;
-    right: 48px;
+    right: 12px;
     width: 14px;
     height: 16px;
 
@@ -174,19 +199,41 @@
     }
   }
 
+  a.octotree_pin {
+    top: 21px;
+    right: 36px;
+    width: 14px;
+    height: 16px;
+
+    &:hover i:before {
+      color: @blue;
+    }
+
+    & i:before {
+      #octicons.pin();
+      color: @dark;
+      font-size: 15px;
+    }
+  }
+
+  a.octotree_pinned i:before {
+    #octicons.pin();
+    transform: rotate(-45deg);
+  }
+
   a.octotree_toggle {
-    top: 14px;
+    top: 50%;
     right: -35px;
 
-    &:not(.octotree_loading) > span:after,
-    &:not(.octotree_loading):hover > span:after {
+    & > span:after,
+    &:hover > span:after {
       #octicons.chevron-right();
       font-size: 15px;
       position: relative;
       left: 3px;
     }
 
-    &:not(.octotree_loading):hover > span:after {
+    &:hover > span:after {
       color: @blue;
     }
   }

--- a/src/core.constants.js
+++ b/src/core.constants.js
@@ -1,10 +1,11 @@
 const NODE_PREFIX = 'octotree';
 const ADDON_CLASS = 'octotree';
 const SHOW_CLASS = 'octotree-show';
+const PINNED_CLASS = 'octotree_pinned';
+const SIDEBAR_HIDING_DELAY = 3000;
 
 const STORE = {
   TOKEN: 'octotree.access_token',
-  REMEMBER: 'octotree.remember',
   NONCODE: 'octotree.noncode_shown',
   PR: 'octotree.pr_shown',
   HOTKEYS: 'octotree.hotkeys',
@@ -12,13 +13,12 @@ const STORE = {
   LOADALL: 'octotree.loadall',
   POPUP: 'octotree.popup_shown',
   WIDTH: 'octotree.sidebar_width',
-  SHOWN: 'octotree.sidebar_shown',
-  GHEURLS: 'octotree.gheurls.shared'
+  GHEURLS: 'octotree.gheurls.shared',
+  PINNED: 'octotree.sidebar_pinned'
 };
 
 const DEFAULTS = {
   TOKEN: '',
-  REMEMBER: true,
   NONCODE: true,
   PR: true,
   LOADALL: true,
@@ -32,6 +32,7 @@ const DEFAULTS = {
 
 const EVENT = {
   TOGGLE: 'octotree:toggle',
+  PIN: 'octotree:pin',
   LOC_CHANGE: 'octotree:location',
   LAYOUT_CHANGE: 'octotree:layout',
   REQ_START: 'octotree:start',
@@ -39,5 +40,6 @@ const EVENT = {
   OPTS_CHANGE: 'octotree:change',
   VIEW_READY: 'octotree:ready',
   VIEW_CLOSE: 'octotree:close',
-  FETCH_ERROR: 'octotree:error'
+  FETCH_ERROR: 'octotree:error',
+  HOTKEYS_CHANGED: 'octotree:change'
 };

--- a/src/styles/base.less
+++ b/src/styles/base.less
@@ -226,7 +226,9 @@
 }
 
 a.octotree_toggle,
-a.octotree_opts {
+a.octotree_opts,
+a.octotree_pin,
+a.octotree_spin, {
   position: absolute !important;
   text-align: center;
   line-height: 1;
@@ -249,31 +251,6 @@ a.octotree_toggle {
   width: 30px;
   height: 30px;
   padding: 6px 6px !important;
-
-  &.octotree_loading {
-    & > span:after {
-      content: '';
-    }
-
-    .loader {
-      border-radius: 50%;
-      border: 2px solid #000;
-      border-top: 2px solid rgba(0, 0, 0, 0);
-      border-left: 2px solid rgba(0, 0, 0, 0);
-      width: 16px;
-      height: 16px;
-      animation: loading 0.5s infinite linear;
-    }
-  }
-
-  @keyframes loading {
-    0% {
-      transform: rotate(0deg);
-    }
-    100% {
-      transform: rotate(360deg);
-    }
-  }
 
   .popup {
     position: absolute;

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -39,4 +39,5 @@
   .file-directory()   {.icon(); content: "\f016";}
   .file-text()        {.icon(); content: "\f011";}
   .file-submodule()   {.icon(); content: "\f017";}
+  .pin()              {.icon(); content: "\f041";}
 }

--- a/src/template.html
+++ b/src/template.html
@@ -1,21 +1,31 @@
 <div>
   <nav class="octotree_sidebar">
     <a class="octotree_toggle btn">
-      <div class="loader"></div>
       <span></span>
-
       <div class="popup">
         <div class="arrow"></div>
         <div class="content">
-          Octotree is enabled on this page. Click this button or press
+          Octotree is enabled on this page. Hover this handle
           <kbd>cmd shift s</kbd> (or <kbd>ctrl shift s</kbd>)
           to show it.
         </div>
       </div>
     </a>
 
+    <a class="octotree_pin" aria-label="Pin/Unpin" data-store="PINNED" href="javascript:void(0)">
+      <span class="tooltipped tooltipped-s" aria-label="Unpin octotree to the page">
+        <i></i>
+      </span>
+    </a>
+
     <a class="octotree_opts" href="javascript:void(0)">
-      <i class="settings"></i>
+      <span class="tooltipped tooltipped-s" aria-label="Settings">
+        <i class="settings"></i>
+      </span>
+    </a>
+
+    <a class="octotree_spin">
+      <span class="loader"></span>
     </a>
 
     <div class="octotree_views">
@@ -72,10 +82,6 @@
             <label><input type="checkbox" data-store="ICONS"> Show file-specific icons</label>
           </div>
           <!-- @endif -->
-
-          <div>
-            <label><input type="checkbox" data-store="REMEMBER"> Remember sidebar visibility</label>
-          </div>
 
           <div>
             <label><input type="checkbox" data-store="NONCODE"> Show in non-code pages</label>

--- a/src/view.tree.js
+++ b/src/view.tree.js
@@ -18,6 +18,10 @@ class TreeView {
     return this.$tree.jstree(true);
   }
 
+  focus() {
+    this.$jstree.get_container().focus();
+  }
+
   show(repo, token) {
     const $jstree = this.$jstree;
 


### PR DESCRIPTION
Changes:
- Unpinned mode:   Open/close sidebar by hover ( Sidebar overlay Github page )
![screen shot 2018-11-03 at 11 15 44 pm](https://user-images.githubusercontent.com/8633840/47954610-6f5dd200-dfbe-11e8-8678-88939d1c47c3.png)
- Pinned mode: always open ( Sidebar push Github page )
![screen shot 2018-11-03 at 11 15 50 pm](https://user-images.githubusercontent.com/8633840/47954615-797fd080-dfbe-11e8-90ad-7da85509917c.png)
- Shortcuts: replace Shown sidebar shortcut with Pin shortcut
- Remove remember sidebar visibility option