### PR TITLE
Remove the constant background color.

### DIFF
--- a/src/styles/base.less
+++ b/src/styles/base.less
@@ -24,7 +24,6 @@
     position: absolute;
     border-top: 1px solid #e1e4e8;
     border-right: 1px solid #e1e4e8;
-    background-color: #fafbfc;
     font-size: 11px;
     line-height: 14px;
     padding: 5px;


### PR DESCRIPTION
It uses the hard background color for the bottom div layer and looks ugly in the dark mode when applying the custom style from stylish extension in google chrome.