### PR TITLE
Add Enable/Disable animations option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ By default, Octotree only works on `github.com`. To support enterprise version (
 * __Remember sidebar visibility__: if checked, show or hide Octotree based on its last visibility.
 * __Show in non-code pages__: if checked, allow Octotree to show in non-code pages such as Issues and Pull Requests.
 * __Load entire tree at once__: if checked, load and render the entire code tree at once. To avoid long loading, this should be unchecked if you frequently work with very large repos.
+* __Enable animations__: if checked, plays a sidebar transition and folder open/close animations.
 * __Show only pull request changes__ _(new!)_: if checked and in "Pull requests" page, only show the change set of the pull request.
 
 ## Contribution

--- a/src/core.constants.js
+++ b/src/core.constants.js
@@ -13,7 +13,8 @@ const STORE = {
   POPUP: 'octotree.popup_shown',
   WIDTH: 'octotree.sidebar_width',
   SHOWN: 'octotree.sidebar_shown',
-  GHEURLS: 'octotree.gheurls.shared'
+  GHEURLS: 'octotree.gheurls.shared',
+  ANIMATIONS: 'octotree.animations'
 };
 
 const DEFAULTS = {
@@ -27,7 +28,8 @@ const DEFAULTS = {
   POPUP: false,
   WIDTH: 232,
   SHOWN: false,
-  GHEURLS: ''
+  GHEURLS: '',
+  ANIMATIONS: true
 };
 
 const EVENT = {

--- a/src/octotree.js
+++ b/src/octotree.js
@@ -48,6 +48,10 @@ $(document).ready(() => {
       .on(EVENT.TOGGLE, layoutChanged)
       .on(EVENT.LOC_CHANGE, () => tryLoadRepo());
 
+    if (!store.get(STORE.ANIMATIONS)) {
+      $sidebar.css('transition', 'none');
+    }
+
     $sidebar
       .width(parseInt(store.get(STORE.WIDTH)))
       .resize(() => layoutChanged(true))

--- a/src/template.html
+++ b/src/template.html
@@ -85,6 +85,10 @@
             <label><input type="checkbox" data-store="LOADALL"> Load entire tree at once</label>
           </div>
 
+          <div>
+            <label><input type="checkbox" data-store="ANIMATIONS"> Enable animations</label>
+          </div>
+
           <div class="octotree_github_only">
             <label>
               <input type="checkbox" data-store="PR">

--- a/src/view.tree.js
+++ b/src/view.tree.js
@@ -9,7 +9,7 @@ class TreeView {
       .on('click.jstree', '.jstree-closed>a', ({target}) => this.$jstree.open_node(target))
       .on('click', this._onItemClick.bind(this))
       .jstree({
-        core: {multiple: false, worker: false, themes: {responsive: false}},
+        core: {multiple: false, worker: false, themes: {responsive: false}, animation: store.get(STORE.ANIMATIONS)*200},
         plugins: ['wholerow']
       });
   }


### PR DESCRIPTION
### Problem
For #596 

### Solution
Adds a new option Enable animations.
It's checked by default - nothing has changed.
If it's unchecked - disables sidebar transition and folder open/close animations.
Default `jstree` animation time is 200ms.

#### Potential problem: 
Page needs to be reloaded after changing the setting to see the effect.
If anyone can suggest a fix, I would appreciate it because I'm not a JS dev.

### Screenshots
![disable-animations](https://user-images.githubusercontent.com/5807561/50910513-0885ea80-143f-11e9-94e1-034e8d7e2900.png)

