### PR TITLE
Optional dark header theme

### DIFF
--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -38,7 +38,7 @@
       .octotree_view_header {
         font-weight: normal;
         text-shadow: none;
-        height: 60px;
+        height: 61px;
         line-height: 2.8;
         background: #fafbfc none;
         border-right: 1px solid #e1e4e8;
@@ -188,6 +188,44 @@
 
     &:not(.octotree_loading):hover > span:after {
       color: @blue;
+    }
+  }
+
+  &.dark {
+    .octotree_views .octotree_view .octotree_view_header {
+      background: #24292e none;
+      border-right: 1px solid #24292e;
+      color: #fff;
+
+      a {
+        color: #fff;
+      }
+    }
+
+    a.octotree_opts {
+      .settings:before  {
+        color: #fff !important;
+      }
+
+      &:hover .settings:before {
+        color: hsla(0,0%,100%,.75) !important;
+      }
+    }
+
+    a.octotree_toggle {
+      color: #fff !important;
+      background-color: #3d4447;
+      background-image: none;
+
+      &.octotree_loading > .loader {
+        border-color: transparent;
+        border-top-color: #fff;
+        border-left-color: #fff;
+      }
+
+      &:not(.octotree_loading):hover > span::after {
+        color: hsla(0,0%,100%,.75);
+      }
     }
   }
 }

--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -38,7 +38,7 @@
       .octotree_view_header {
         font-weight: normal;
         text-shadow: none;
-        height: 61px;
+        height: 60px;
         line-height: 2.8;
         background: #fafbfc none;
         border-right: 1px solid #e1e4e8;
@@ -195,6 +195,7 @@
     .octotree_views .octotree_view .octotree_view_header {
       background: #24292e none;
       border-right: 1px solid #24292e;
+      border-bottom: none;
       color: #fff;
 
       a {

--- a/src/core.constants.js
+++ b/src/core.constants.js
@@ -13,7 +13,8 @@ const STORE = {
   POPUP: 'octotree.popup_shown',
   WIDTH: 'octotree.sidebar_width',
   SHOWN: 'octotree.sidebar_shown',
-  GHEURLS: 'octotree.gheurls.shared'
+  GHEURLS: 'octotree.gheurls.shared',
+  DARKHEADER: 'octotree.header.dark'
 };
 
 const DEFAULTS = {
@@ -27,7 +28,8 @@ const DEFAULTS = {
   POPUP: false,
   WIDTH: 232,
   SHOWN: false,
-  GHEURLS: ''
+  GHEURLS: '',
+  DARKHEADER: false
 };
 
 const EVENT = {

--- a/src/octotree.js
+++ b/src/octotree.js
@@ -28,9 +28,7 @@ $(document).ready(() => {
     key.filter = () => $toggler.is(':visible');
     key(store.get(STORE.HOTKEYS), toggleSidebarAndSave);
 
-    if (store.get(STORE.DARKHEADER)) {
-      $sidebar.addClass('dark');
-    }
+    applyTheme(store.get(STORE.DARKHEADER));
 
     for (const view of [treeView, errorView, optsView]) {
       $(view)
@@ -91,6 +89,14 @@ $(document).ready(() => {
       }
     }
 
+    function applyTheme(useDarkTheme) {
+      if (useDarkTheme) {
+        $sidebar.addClass('dark');
+      } else {
+        $sidebar.removeClass('dark');
+      }
+    }
+
     /**
      * Invoked when the user saves the option changes in the option view.
      * @param {!string} event
@@ -98,6 +104,8 @@ $(document).ready(() => {
      */
     async function optionsChanged(event, changes) {
       let reload = false;
+
+      applyTheme(store.get(STORE.DARKHEADER));
 
       Object.keys(changes).forEach((storeKey) => {
         const value = changes[storeKey];
@@ -107,7 +115,6 @@ $(document).ready(() => {
           case STORE.LOADALL:
           case STORE.ICONS:
           case STORE.PR:
-          case STORE.DARKHEADER:
             reload = true;
             break;
           case STORE.HOTKEYS:

--- a/src/octotree.js
+++ b/src/octotree.js
@@ -28,6 +28,10 @@ $(document).ready(() => {
     key.filter = () => $toggler.is(':visible');
     key(store.get(STORE.HOTKEYS), toggleSidebarAndSave);
 
+    if (store.get(STORE.DARKHEADER)) {
+      $sidebar.addClass('dark');
+    }
+
     for (const view of [treeView, errorView, optsView]) {
       $(view)
         .on(EVENT.VIEW_READY, function(event) {
@@ -103,6 +107,7 @@ $(document).ready(() => {
           case STORE.LOADALL:
           case STORE.ICONS:
           case STORE.PR:
+          case STORE.DARKHEADER:
             reload = true;
             break;
           case STORE.HOTKEYS:

--- a/src/template.html
+++ b/src/template.html
@@ -93,6 +93,10 @@
             </label>
           </div>
 
+          <div class="octotree_theme_dark">
+            <label><input type="checkbox" data-store="DARKHEADER"> Use dark header</label>
+          </div>
+
           <div>
             <button type="submit" class="btn">Save</button>
           </div>


### PR DESCRIPTION
### Problem

Sidebar header and GitHub header styles inconsistency

### Solution

Optional parameter to enable dark theme for sidebar header

### Screenshots

#### Before:

![image](https://user-images.githubusercontent.com/827338/50999927-9dbad900-153c-11e9-8e64-50095e3e6d27.png)

#### After:

![kapture 2019-01-11 at 1 01 38](https://user-images.githubusercontent.com/827338/50999958-b6c38a00-153c-11e9-885e-cfab1d7ea3c5.gif)


