### PR TITLE
Fix long branch names with ellipsis resulting in Error: Private repository

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -149,7 +149,7 @@ class GitHub extends PjaxAdapter {
       // Pick the commit ID or branch name from the Branch dropdown menu
       // Note: we can't use URL as it would not work with branches with slashes, e.g. features/hotfix-1
       $('.select-menu-item.selected', branchDropdownMenu).data('name') ||
-      $('.select-menu-button span', branchDropdownMenu).text() ||
+      (!$('.select-menu-button span', branchDropdownMenu).text().includes('…') && $('.select-menu-button span', branchDropdownMenu).text()) ||
       // Pull requests page
       ($('.commit-ref.base-ref').attr('title') || ':').match(/:(.*)/)[1] ||
       // Reuse last selected branch if exist

--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -149,7 +149,7 @@ class GitHub extends PjaxAdapter {
       // Pick the commit ID or branch name from the Branch dropdown menu
       // Note: we can't use URL as it would not work with branches with slashes, e.g. features/hotfix-1
       $('.select-menu-item.selected', branchDropdownMenu).data('name') ||
-      $('.select-menu-button span', branchDropdownMenu).attr('title') ||
+      $('.select-menu-button', branchDropdownMenu).attr('title') ||
       $('.select-menu-button span', branchDropdownMenu).text() ||
       // Pull requests page
       ($('.commit-ref.base-ref').attr('title') || ':').match(/:(.*)/)[1] ||

--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -149,7 +149,8 @@ class GitHub extends PjaxAdapter {
       // Pick the commit ID or branch name from the Branch dropdown menu
       // Note: we can't use URL as it would not work with branches with slashes, e.g. features/hotfix-1
       $('.select-menu-item.selected', branchDropdownMenu).data('name') ||
-      (!$('.select-menu-button span', branchDropdownMenu).text().includes('…') && $('.select-menu-button span', branchDropdownMenu).text()) ||
+      $('.select-menu-button span', branchDropdownMenu).attr('title') ||
+      $('.select-menu-button span', branchDropdownMenu).text() ||
       // Pull requests page
       ($('.commit-ref.base-ref').attr('title') || ':').match(/:(.*)/)[1] ||
       // Reuse last selected branch if exist


### PR DESCRIPTION
### Problem
For #602

### Solution
If a branch is too long and contains an ellipsis `…` (three dots), then don't use that name as a branch name.
It falls back and tries other available methods.