### PR TITLE
Enabling Windows command line path for mocha

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,10 @@ gulp.task('dist', ['build'], (cb) => {
 });
 
 gulp.task('test', ['build'], (cb) => {
-  const ps = spawn('./node_modules/.bin/mocha', [
+  var isWindowsEnvironment = process.platform === "win32";
+  var mochaBinPath = isWindowsEnvironment?'.\\node_modules\\.bin\\mocha.cmd':'./node_modules/.bin/mocha';
+
+  const ps = spawn(mochaBinPath, [
     '--harmony',
     '--reporter',
     'spec',


### PR DESCRIPTION
### Problem
 Mocha is not working under Windows

### Solution
The solution fixes issue #605 and is provided by changing the gulpfile.js.
In the corresponding gulp task "test", the task first checks whether there is a Windows environment present. If yes, a working Windows path extension for mocha (with backslashes and .cmd) is used. Otherwise, the default path for mocha is used.

Fixes #605 

### Screenshots
N/A
