### PR TITLE
Fix issue of folders opening or closing twice in a row

### DIFF
--- a/src/view.tree.js
+++ b/src/view.tree.js
@@ -5,8 +5,16 @@ class TreeView {
     this.$view = $dom.find('.octotree_treeview');
     this.$tree = this.$view
       .find('.octotree_view_body')
-      .on('click.jstree', '.jstree-open>a', ({target}) => this.$jstree.close_node(target))
-      .on('click.jstree', '.jstree-closed>a', ({target}) => this.$jstree.open_node(target))
+      .on('click.jstree', '.jstree-open>a', ({target}) => {
+        setTimeout(() => {
+          this.$jstree.close_node(target)
+        }, 0);
+      })
+      .on('click.jstree', '.jstree-closed>a', ({target}) => {
+        setTimeout(() => {
+          this.$jstree.open_node(target)
+        }, 0);
+      })
       .on('click', this._onItemClick.bind(this))
       .jstree({
         core: {multiple: false, worker: false, themes: {responsive: false}},


### PR DESCRIPTION
### Problem
Very often when I attempt to close or open a folder in the tree view, the following can happen:
- If the folder is closed, it will stay closed
- If the folder is opened, it will transition instantly to the close state and redo the opening animation 
- Usually it can be reproduced by clicking one folder, then clicking another different folder twice

### Solution
By wrapping the close and open functions in a setTimeout, the issue disappears. It seems like the issue happens due to the functions getting called too early.

### Screenshots
N/A

closes #613