### PR TITLE
fixed character-cut bug in private repository

### DIFF
--- a/src/adapters/adapter.js
+++ b/src/adapters/adapter.js
@@ -236,7 +236,7 @@ class Adapter {
         break;
     }
     cb({
-      error: `Error: ${error}`,
+      error: `Error: <br/>${error}`,
       message: message,
       needAuth: needAuth
     });

--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -73,6 +73,13 @@
       }
     }
 
+    .octotree_errorview{
+      .octotree_view_header{
+        padding-top: 9px;
+        line-height: 1.3;
+      }
+    }
+    
     .octotree_treeview {
       .octotree_header_repo {
         font-size: 13px;


### PR DESCRIPTION
### Problem
character-cut bug

### Solution
modify css & error message

src/adapters/adapter.js 239 
`error: Error: <br/> ${error},`

src/adapters/github.less 76
`.octotree_errorview{
      .octotree_view_header{
        padding-top: 9px;
        line-height: 1.3;
      }
    }
`


### Screenshots
[before google drive](https://drive.google.com/open?id=1fdEnC1NXyHjxRF__BEO-hHdOpsM8M6Za) 
[after google drive](https://drive.google.com/open?id=1JgEkLWyajeWKDHC5GD-ACOvGZG_ZnHZF)