### PR TITLE
Private repository load error in private repository

### DIFF
--- a/src/octotree.js
+++ b/src/octotree.js
@@ -122,7 +122,6 @@ $(document).ready(() => {
     }
 
     function tryLoadRepo(reload) {
-      hasError = false;
       const remember = store.get(STORE.REMEMBER);
       const shown = store.get(STORE.SHOWN);
       const token = store.get(STORE.TOKEN);


### PR DESCRIPTION
### Problem
Press the toggle button twice.  -> Press the setting button twice. -> An error occurs.

### Solution
src / octotree.js 254 
`hasError = false;` remove 

### Screenshots
same repository 

[before google drive](https://drive.google.com/open?id=1uH-W3a7gq-bqZFYQ21Y-5Ha6Q2QfJ3EO)
[after google drive](https://drive.google.com/open?id=1uRbU0wYVtpDGXSLEmN8BkX77aLuAbk2E)
