### PR TITLE
Mark huge repositories to load lazily later (#595)

### DIFF
--- a/src/adapters/adapter.js
+++ b/src/adapters/adapter.js
@@ -237,7 +237,8 @@ class Adapter {
     cb({
       error: `Error: ${error}`,
       message: message,
-      needAuth: needAuth
+      needAuth: needAuth,
+      status: jqXHR.status
     });
   }
 

--- a/src/adapters/adapter.js
+++ b/src/adapters/adapter.js
@@ -191,8 +191,7 @@ class Adapter {
       case 206:
         error = 'Repo too large';
         message = `This repository is too large to loaded in a single request.
-          If you frequently work with this repository,
-          go to Settings and uncheck the "Load entire tree at once" option.`;
+          For subsequent requests the repository will be loaded lazily. Please refresh the page to see the results.`;
         break;
       case 401:
         error = 'Invalid token';
@@ -271,7 +270,7 @@ class Adapter {
    * a single request. This is usually determined by the underlying the API.
    * @api public
    */
-  canLoadEntireTree() {
+  canLoadEntireTree(opts) {
     return false;
   }
 

--- a/src/adapters/adapter.js
+++ b/src/adapters/adapter.js
@@ -188,11 +188,6 @@ class Adapter {
           Please try again later.`;
         needAuth = false;
         break;
-      case 206:
-        error = 'Repo too large';
-        message = `This repository is too large to loaded in a single request.
-          For subsequent requests the repository will be loaded lazily. Please refresh the page to see the results.`;
-        break;
       case 401:
         error = 'Invalid token';
         message = `The token is invalid.

--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -73,8 +73,10 @@ class GitHub extends PjaxAdapter {
   }
 
   // @override
-  canLoadEntireTree() {
-    return true;
+  canLoadEntireTree(repo) {
+    const key = `${repo.username}/${repo.reponame}`;
+    const hugeRepos = this.store.get(STORE.HUGE_REPOS);
+    return !(hugeRepos[key] === true);
   }
 
   // @override
@@ -306,6 +308,12 @@ class GitHub extends PjaxAdapter {
     $.ajax(cfg)
       .done((data) => {
         if (path && path.indexOf('/git/trees') === 0 && data.truncated) {
+          const hugeRepos = this.store.get(STORE.HUGE_REPOS);
+          const repo = `${opts.repo.username}/${opts.repo.reponame}`;
+          if (undefined === hugeRepos[repo]) {
+            hugeRepos[repo] = true;
+            this.store.set(STORE.HUGE_REPOS, hugeRepos);
+          }
           this._handleError({status: 206}, cb);
         } else cb(null, data);
       })

--- a/src/core.constants.js
+++ b/src/core.constants.js
@@ -13,7 +13,8 @@ const STORE = {
   POPUP: 'octotree.popup_shown',
   WIDTH: 'octotree.sidebar_width',
   SHOWN: 'octotree.sidebar_shown',
-  GHEURLS: 'octotree.gheurls.shared'
+  GHEURLS: 'octotree.gheurls.shared',
+  HUGE_REPOS: 'octotree.huge_repos'
 };
 
 const DEFAULTS = {
@@ -27,7 +28,8 @@ const DEFAULTS = {
   POPUP: false,
   WIDTH: 232,
   SHOWN: false,
-  GHEURLS: ''
+  GHEURLS: '',
+  HUGE_REPOS: {}
 };
 
 const EVENT = {

--- a/src/octotree.js
+++ b/src/octotree.js
@@ -145,7 +145,7 @@ $(document).ready(() => {
               currRepo = repo;
               treeView.show(repo, token);
             } else {
-              treeView.syncSelection();
+              treeView.syncSelection(repo);
             }
           }
         } else {

--- a/src/view.tree.js
+++ b/src/view.tree.js
@@ -29,7 +29,11 @@ class TreeView {
 
       this.adapter.loadCodeTree({repo, token, node}, (err, treeData) => {
         if (err) {
-          $(this).trigger(EVENT.FETCH_ERROR, [err]);
+          if (err.status === 206 && loadAll) { // The repo is too big to load all, need to retry
+            $jstree.refresh(true);
+          } else {
+            $(this).trigger(EVENT.FETCH_ERROR, [err]);
+          }
         } else {
           treeData = this._sort(treeData);
           if (loadAll) {

--- a/src/view.tree.js
+++ b/src/view.tree.js
@@ -23,7 +23,7 @@ class TreeView {
 
     $jstree.settings.core.data = (node, cb) => {
       const prMode = this.store.get(STORE.PR) && repo.pullNumber;
-      const loadAll = this.adapter.canLoadEntireTree() && (prMode || this.store.get(STORE.LOADALL));
+      const loadAll = this.adapter.canLoadEntireTree(repo) && (prMode || this.store.get(STORE.LOADALL));
 
       node = !loadAll && (node.id === '#' ? {path: ''} : node.original);
 
@@ -41,7 +41,7 @@ class TreeView {
     };
 
     this.$tree.one('refresh.jstree', () => {
-      this.syncSelection();
+      this.syncSelection(repo);
       $(this).trigger(EVENT.VIEW_READY);
     });
 
@@ -149,7 +149,7 @@ class TreeView {
     }
   }
 
-  syncSelection() {
+  syncSelection(repo) {
     const $jstree = this.$jstree;
     if (!$jstree) return;
 
@@ -159,7 +159,7 @@ class TreeView {
     if (!match) return;
 
     const currentPath = match[1];
-    const loadAll = this.adapter.canLoadEntireTree() && this.store.get(STORE.LOADALL);
+    const loadAll = this.adapter.canLoadEntireTree(repo) && this.store.get(STORE.LOADALL);
 
     selectPath(loadAll ? [currentPath] : breakPath(currentPath));
 


### PR DESCRIPTION
When it discovers that repo is too big to load it marks it and stores in the storage. Before each request it checks if the repo is huge. 

The first time it wants to fetch a huge repo it asks to refresh the page. This is "hack"-ish fix, since we need to retry loading lazily immediately. Could not find an elegant way to do this. 