### PR TITLE
Fix(branch name guessing): handle `/` in branch name when using link

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -170,9 +170,9 @@ class GitHub extends PjaxAdapter {
       (type === 'commit' && typeId) ||
       // Pick the commit ID or branch name from the DOM
       // Note: we can't use URL as it would not work with branches with slashes, e.g. features/hotfix-1
+      branchFromSummary ||
       ($('.overall-summary .numbers-summary .commits a').attr('href') || '')
         .replace(`/${username}/${reponame}/commits/`, '') ||
-      branchFromSummary ||
       // Pull requests page
       ($('.commit-ref.base-ref').attr('title') || ':').match(/:(.*)/)[1] ||
       // Reuse last selected branch if exist

--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -170,7 +170,8 @@ class GitHub extends PjaxAdapter {
       (type === 'commit' && typeId) ||
       // Pick the commit ID or branch name from the DOM
       // Note: we can't use URL as it would not work with branches with slashes, e.g. features/hotfix-1
-      ($('.overall-summary .numbers-summary .commits a').attr('href') || '').split('/').slice(-1)[0] ||
+      ($('.overall-summary .numbers-summary .commits a').attr('href') || '')
+        .replace(`/${username}/${reponame}/commits/`, '') ||
       branchFromSummary ||
       // Pull requests page
       ($('.commit-ref.base-ref').attr('title') || ':').match(/:(.*)/)[1] ||


### PR DESCRIPTION
### Problem

The branch name is not correctly parsed when it contains a `/`

### Solution

When parsing the commits list, delete the initial `/username/reponame/commits/` instead of getting the last `/`.

You can check with this [PR branch](https://github.com/enizor/octotree/tree/enizor/fix-branch): the extension tried to use `fix-branch` instead of the whole `enizor/fix-branch` 

Maybe `currentRepo.username` should be used instead of only `username` (and similarly for `reponame`) but I did not understand when the two could differ