### PR TITLE
Prevent mouseenter triggered when mouse is out of the sidebar

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -233,7 +233,12 @@ $(document).ready(() => {
         startTimer(MOUSE_LEAVE_DELAY);
       });
       $sidebar.on('mouseenter mousemove', (event) => {
-        // Mouse is out
+        /**
+         * When loading a new file, the page is re-rendered,
+         * which triggers the mouseenter event even the mouse is actually out.
+         * Ensure the mouse is in the sidebar before running this event handler.
+         */
+
         if (!event.clientX) return;
 
         isMouseInSidebar = true;

--- a/src/main.js
+++ b/src/main.js
@@ -232,7 +232,10 @@ $(document).ready(() => {
         isMouseInSidebar = false;
         startTimer(MOUSE_LEAVE_DELAY);
       });
-      $sidebar.on('mouseenter mousemove', () => {
+      $sidebar.on('mouseenter mousemove', (event) => {
+        // Mouse is out
+        if (!event.clientX) return;
+
         isMouseInSidebar = true;
         clearTimer();
         if (!isSidebarVisible()) toggleSidebar(true);


### PR DESCRIPTION
### Problem
Click file and mouse out doesn't automatically hide the sidebar in float mode. The reason is when loading a new file, `mouseenter` in the side is triggered after the file is loaded even the mouse is moved out the sidebar already.
### Solution
Check if mouse is out the sidebar in the `mouseenter` event.