### PR TITLE
Footer covering the last item fixed

### DIFF
--- a/src/styles/base.less
+++ b/src/styles/base.less
@@ -58,6 +58,7 @@
 
   .octotree_view {
     display: none;
+    margin-bottom: 30px;
     box-sizing: border-box;
 
     &.current {


### PR DESCRIPTION
### Problem
#594 Footer cover the last item

### Solution
Leave margin at bottom so that last file/folder is visible in the tree.

### Screenshots
#### Before fix
![Screenshot from 2019-03-14 14-22-00](https://user-images.githubusercontent.com/17037667/54343430-c9555f00-4664-11e9-9673-ef9c9fffbcfc.png)

#### After fix
![Screenshot from 2019-03-14 14-21-31](https://user-images.githubusercontent.com/17037667/54343439-d1150380-4664-11e9-93a2-f11d82aa4191.png)
