### PR TITLE
fix: hide the resizable sidebar completely

### DIFF
--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -23,6 +23,7 @@
 
   .ui-resizable-e {
     right: -4px;
+    width: 0px;
   }
 
   .octotree-footer {


### PR DESCRIPTION
Address https://github.com/ovity/octotree/issues/659