### PR TITLE
fix: error shown when sidebar is closed in float mode

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -157,7 +157,8 @@ $(document).ready(() => {
     function showError(err) {
       hasError = true;
       errorView.show(err);
-      toggleSidebar(true);
+
+      if (store.get(STORE.PINNED)) togglePin(true);
     }
 
     function toggleSidebar(visibility) {


### PR DESCRIPTION
Address https://github.com/ovity/octotree/issues/663
