### PR TITLE
fix header's left padding styling when large screen

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -112,7 +112,7 @@ class GitHub extends PjaxAdapter {
 
     $('html').css('margin-left', shouldPushEverything && smallScreen ? sidebarWidth : '');
     $containers.css('margin-left', shouldPushEverything && smallScreen ? SPACING : '');
-    $header.css('padding-left', shouldPushEverything && !smallScreen ? sidebarWidth : '');
+    $header.css('padding-left', shouldPushEverything && !smallScreen ? sidebarWidth + SPACING : '');
   }
 
   // @override


### PR DESCRIPTION
### Problem

GitHub branding logo is not given left gutter spacing when large window.

### Solution
I added SPACING (10px)

### Screenshots

* before  
![before](https://i.gyazo.com/3e3ec5f3ff426d5521b44bc9ac49c176.png)
* after  
![after](https://i.gyazo.com/77a9f69ff2f5e2a47662cbdce59e7301.png)

