### PR TITLE
Show full icon branch

### DIFF
--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -158,6 +158,7 @@
         .octotree-header-branch {
           line-height: 1;
           margin-left: -1px;
+          padding-bottom: 1px;
           font-size: 11px;
           color: white;
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/19208123/56810919-b20fb100-6861-11e9-8ce1-d72fbb775799.png)


After:
![image](https://user-images.githubusercontent.com/19208123/56810837-770d7d80-6861-11e9-8375-21e9eb82c0d5.png)

This commit will show full icon branch.

I am using lastest chrome version.