### PR TITLE
Enhancement: hide octotree on "users" page

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -32,7 +32,8 @@ const GH_RESERVED_USER_NAMES = [
   'personal',
   'pricing',
   'sessions',
-  'topics'
+  'topics',
+  'users'
 ];
 const GH_RESERVED_REPO_NAMES = ['followers', 'following', 'repositories'];
 const GH_404_SEL = '#parallax_wrapper';


### PR DESCRIPTION
The URL path prefix "/users" is used for the new "sponsorship" feature of GitHub.

### Problem
We don't need the sidebar on these pages.

### Screenshots
Screenshots before and after applying the PR.
![image](https://user-images.githubusercontent.com/424602/58316946-0f713080-7e15-11e9-8736-76e5a7ad1b75.png)

