### PR TITLE
Add 'marketplace' to reserved usernames

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -30,7 +30,8 @@ const GH_RESERVED_USER_NAMES = [
   'mirrors',
   'open-source',
   'personal',
-  'pricing'
+  'pricing',
+  'marketplace',
 ];
 const GH_RESERVED_REPO_NAMES = ['followers', 'following', 'repositories'];
 const GH_404_SEL = '#parallax_wrapper';


### PR DESCRIPTION
### Problem
Octo-tree shows up on marketplace pages.

### Solution

Added `marketplace` to the `GH_RESERVED_USER_NAMES`

### Screenshots

Before:

![image](https://user-images.githubusercontent.com/6426069/59787121-6ff56f80-92e6-11e9-98ec-c71756a15a39.png)

After:

(pending)
