### PR TITLE
Resolve issue #741 - tall letters are cut off

### DIFF
--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -118,7 +118,6 @@
 
         .octotree-header-summary {
           width: 100%;
-          height: @header-height / 2;
         }
 
         .octotree-header-repo,
@@ -134,6 +133,7 @@
           margin-bottom: 3px;
 
           font-size: 13px;
+          line-height: 16px;
           font-weight: normal;
           color: white;
 
@@ -144,7 +144,7 @@
 
           .octotree-icon-repo {
             .icon-v2(@octicons-repo, @color: white, @hover-color: white);
-            top: 2px;
+            vertical-align: middle;
           }
 
           a {


### PR DESCRIPTION
### Problem
https://github.com/ovity/octotree/issues/741

### Solution
Modify CSS.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/28825116/62011764-bde37a00-b1a6-11e9-87af-4d2399093788.png)

After:
![image](https://user-images.githubusercontent.com/28825116/62011757-a906e680-b1a6-11e9-8d10-c23ce57c41c1.png)

