### PR TITLE
add full path is shown upon hover

### DIFF
--- a/src/adapters/adapter.js
+++ b/src/adapters/adapter.js
@@ -59,6 +59,9 @@ class Adapter {
 
             item.id = NODE_PREFIX + path;
             item.text = name;
+            item.li_attr = {
+              'title': path
+            };
 
             // Uses `type` as class name for tree node
             item.icon = type;


### PR DESCRIPTION
### Problem
When path name is long, the current text is shown with "...".
### Solution
Set 'title' for directory/file name so that full path is shown upon hover
### Screenshots

![Screen Shot 2019-09-07 at 5 12 05 PM](https://user-images.githubusercontent.com/10753722/64472660-88ae4c80-d194-11e9-9366-3c8014d3df09.png)
