### PR TITLE
Add disclaimer message for personal token usage.

### DIFF
--- a/src/adapters/adapter.js
+++ b/src/adapters/adapter.js
@@ -59,6 +59,9 @@ class Adapter {
 
             item.id = NODE_PREFIX + path;
             item.text = name;
+            item.li_attr = {
+              'title': path
+            };
 
             // Uses `type` as class name for tree node
             item.icon = type;

--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -353,6 +353,11 @@
           height: 60px;
         }
 
+        .octotree-disclaimer-token {
+          font-size: 0.8em;
+          margin-top: 6px;
+        }
+
         .octotree-disclaimer {
           color: @gray;
           display: block;

--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -350,17 +350,14 @@
           resize: vertical;
           height: 60px;
         }
-
-        .octotree-disclaimer-token {
-          font-size: 0.8em;
-          margin-top: 6px;
-        }
-
+        
         .octotree-disclaimer {
-          color: @gray;
           display: block;
           font-size: 12px;
-          margin-left: 18px;
+
+          &.is-margin-left {
+            margin-left: 18px;
+          }
         }
       }
 

--- a/src/template.html
+++ b/src/template.html
@@ -56,7 +56,7 @@
               </a>
             </div>
             <input type="text" class="form-control input-block" data-store="TOKEN" />
-            <div class="octotree-disclaimer-token text-gray text-mono">The access token is stored in your browser local storage and Octotree uses it only to communicate with GitHub API.</div>
+            <div class="octotree-disclaimer text-gray">Token is stored in local storage.</div>
           </div>
 
           <div>
@@ -116,7 +116,7 @@
           <div>
             <label>
               <input type="checkbox" data-store="PR" /> <span>Show pull request changes</span>
-              <span class="octotree-disclaimer">Note: maximum of 300 files</span>
+              <span class="octotree-disclaimer is-margin-left text-gray">Note: maximum of 300 files</span>
             </label>
           </div>
 

--- a/src/template.html
+++ b/src/template.html
@@ -56,6 +56,7 @@
               </a>
             </div>
             <input type="text" class="form-control input-block" data-store="TOKEN" />
+            <div class="octotree-disclaimer-token text-gray text-mono">The access token is stored in your browser local storage and Octotree uses it only to communicate with GitHub API.</div>
           </div>
 
           <div>


### PR DESCRIPTION
### Problem
Disclaimer message for personal token usage in Octotree is not shown in settings view  
### Solution
Adding a disclaimer message to make it clear token is stored in local storage.
### Screenshots
![Screen Shot 2019-09-08 at 5 27 30 PM](https://user-images.githubusercontent.com/10753722/64486400-587fb000-d25f-11e9-84fb-b0978ee798f9.png)
