### PR TITLE
fix tooltip hidden

### DIFF
--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -288,8 +288,6 @@
 
     .octotree-error-view,
     .octotree-settings-view {
-      overflow: auto;
-      height: ~"calc(100% - 215px)";
       .octotree-view-header {
         padding-left: 8px;
       }


### PR DESCRIPTION
Tooltips in settings are hidden because of the overflow attribute