### PR TITLE
Add reload argument to LOC_CHANGE event

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -57,7 +57,7 @@ $(document).ready(() => {
       .on(EVENT.REQ_END, () => $spinner.removeClass('octotree-spin--loading'))
       .on(EVENT.LAYOUT_CHANGE, layoutChanged)
       .on(EVENT.TOGGLE_PIN, layoutChanged)
-      .on(EVENT.LOC_CHANGE, () => tryLoadRepo());
+      .on(EVENT.LOC_CHANGE, (event, reload = false) => tryLoadRepo(reload));
 
     $sidebar
       .addClass(adapter.getCssClass())


### PR DESCRIPTION
### Problem
This change is required for handling events in octotree pro feature (caching repo). For example once force reload is clicked the reload for both repo and cache should happen.

## Solution
add boolean argument to EVENT.LOC_CHANGE to be passed into tryLoadRepo function.

