### PR TITLE
Exclude customer-stories URL's from repository recognition.

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -34,7 +34,8 @@ const GH_RESERVED_USER_NAMES = [
   'sessions',
   'topics',
   'users',
-  'marketplace'
+  'marketplace',
+  'customer-stories'
 ];
 const GH_RESERVED_REPO_NAMES = ['followers', 'following', 'repositories'];
 const GH_404_SEL = '#parallax_wrapper';


### PR DESCRIPTION
### Problem
This addresses issue #797, another set of URL's that are not repositories.

### Solution
`customer-stories` is added to `GH_RESERVED_USER_NAMES`.

Note: Maybe `GH_RESERVED_USER_NAMES` should be alphabetized, for easier reference in the future? Happy to do this if desired.