### PR TITLE
Add collections to GH_RESERVED_USER_NAMES

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -34,7 +34,8 @@ const GH_RESERVED_USER_NAMES = [
   'sessions',
   'topics',
   'users',
-  'marketplace'
+  'marketplace',
+  'collections'
 ];
 const GH_RESERVED_REPO_NAMES = ['followers', 'following', 'repositories'];
 const GH_404_SEL = '#parallax_wrapper';


### PR DESCRIPTION
* fixes #808 

### Problem
Octotree appears on collection pages.

### Steps to reproduce:
Visit any page under [Github Collections](https://github.com/collections), e.g:
* [Clean code linters](https://github.com/collections/clean-code-linters)
* [Open journalism](https://github.com/collections/open-journalism)

### Solution
add `collections` to `GH_RESERVED_USER_NAMES`.