### PR TITLE
Default to master branch on releases and tags pages. Fixes #743.

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -135,6 +135,8 @@ class GitHub extends PjaxAdapter {
     const branch =
       // Pick the commit ID as branch name when the code page is listing tree in a particular commit
       (type === 'commit' && typeId) ||
+      // Pick 'master' as branch name when viewing repo's releases or tags
+      ((type === 'releases' || type === 'tags') && 'master') ||
       // Pick the commit ID or branch name from the DOM
       branchFromSummary ||
       ($('.overall-summary .numbers-summary .commits a').attr('href') || '').replace(


### PR DESCRIPTION
### Problem
Some GitHub-themed Chrome extensions cause problems for Octotree because they reuse the branch-picker dropdown (specifically the `branch-select-menu` class) for other purposes, and Octotree's branch detection grabs an invalid value for the branch name, which cases the tree to fail to load.

### Solution
This PR solves this problem in the releases and tags pages, by choosing `master` for the branch when at those url's. This works well because releases and tags are not per-branch git features anyway.