### PR TITLE
Show pull request head with branch name. Fixes #542.

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -151,7 +151,9 @@ class GitHub extends PjaxAdapter {
     const isPR = type === 'pull';
     const showOnlyChangedInPR = this.store.get(STORE.PR);
     const pullNumber = isPR && showOnlyChangedInPR ? typeId : null;
-    const repo = {username, reponame, branch, pullNumber};
+    const pullHead = isPR ? ($('.commit-ref.head-ref').attr('title') || ':').match(/:(.*)/)[1] : null;
+    const displayBranch = isPR && pullHead ? `${branch} < ${pullHead}` : null;
+    const repo = {username, reponame, branch, displayBranch, pullNumber};
     if (repo.branch) {
       cb(null, repo);
     } else {

--- a/src/view.tree.js
+++ b/src/view.tree.js
@@ -76,7 +76,7 @@ class TreeView {
           </div>
           <div class="octotree-header-branch">
             <i class="octotree-icon-branch"></i>
-            ${deXss(repo.branch.toString())}
+            ${deXss((repo.displayBranch || repo.branch).toString())}
           </div>
         </div>`
       )


### PR DESCRIPTION
### Problem
Currently, in PR view, Octotree only shows the base branch as the branch name, and does not mention the head.

### Solution
This PR detects the head branch (merge origin) name, and shows the branch name as "base < head", e.g. "master < new-shiny-feature".

### Screenshots
Shown here in one of this repo's PR's:
<img width="1048" alt="Screen Shot 2019-10-04 at 11 57 20 PM" src="https://user-images.githubusercontent.com/6874678/66250078-28fb8080-e703-11e9-8e36-22ac79f0f133.png">
