### PR TITLE
fix checkbox vertical alignment

### DIFF
--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -288,8 +288,14 @@
 
     .octotree-error-view,
     .octotree-settings-view {
+      overflow: auto;
       .octotree-view-header {
         padding-left: 8px;
+      }
+      .octotree-view-body {
+        input[type="checkbox"], input[type="radio"] {
+          vertical-align: middle;
+        }
       }
     }
 


### PR DESCRIPTION
### Problem
The checkboxes in the setting screen are not well aligned with the label

### Solution
Add vertical-align: middle;

### Screenshots
Before
![image](https://user-images.githubusercontent.com/28825116/66701026-61ade200-ed21-11e9-982a-db77503a9f79.png)
After
![image](https://user-images.githubusercontent.com/28825116/66701034-768a7580-ed21-11e9-818b-7dba15dec271.png)

