### PR TITLE
fix overflow issue in setting screen

### DIFF
--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -292,7 +292,6 @@
 
     .octotree-error-view,
     .octotree-settings-view {
-      overflow: auto;
       .octotree-view-header {
         padding-left: 8px;
       }


### PR DESCRIPTION
### Problem
![image](https://user-images.githubusercontent.com/28825116/66944671-d82b4680-f077-11e9-9d55-486b4ca0c41c.png)


### Solution
Remove `overflow: hidden;` on octotree-setting-view

### Screenshots
![image](https://user-images.githubusercontent.com/28825116/66944985-74ede400-f078-11e9-9558-d4639039b301.png)


