### PR TITLE
hide toggler by default

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,12 @@
 $(document).ready(() => {
-  if (octotree.shouldShowOctotree()) {
-    octotree.load(loadExtension);
-  }
+  octotree.load(loadExtension);
 
   async function loadExtension(activationOpts = {}) {
     const $html = $('html');
     const $document = $(document);
     const $dom = $(TEMPLATE);
     const $sidebar = $dom.find('.octotree-sidebar');
-    const $toggler = $sidebar.find('.octotree-toggle');
+    const $toggler = $sidebar.find('.octotree-toggle').hide();
     const $views = $sidebar.find('.octotree-view');
     const $spinner = $sidebar.find('.octotree-spin');
     const $pinner = $sidebar.find('.octotree-pin');


### PR DESCRIPTION
### Problem
On non-repo pages, the toggler appears for 1 sec then disappears

### Solution
Hide the toggler by default, so that it does not need to wait for that 1 sec to get hidden
