### PR TITLE
Add tool to expand or collapse folders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "octotree",
-  "version": "3.0.0",
+  "version": "3.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -443,9 +443,9 @@
       "integrity": "sha1-x8eTaigKZPj6Dl9hCLoi+SxjljM=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000885",
-        "fs-extra": "0.10.0",
-        "postcss": "2.1.2"
+        "caniuse-db": "^1.0.20140727",
+        "fs-extra": "~0.10.0",
+        "postcss": "~2.1.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -454,10 +454,10 @@
           "integrity": "sha1-mcDsL9XqqtnWRiReSwFLVnKZgq8=",
           "dev": true,
           "requires": {
-            "jsonfile": "1.2.0",
-            "mkdirp": "0.5.1",
-            "ncp": "0.5.1",
-            "rimraf": "2.6.2"
+            "jsonfile": "^1.2.0",
+            "mkdirp": "^0.5.0",
+            "ncp": "^0.5.1",
+            "rimraf": "^2.2.8"
           }
         },
         "jsonfile": {
@@ -3921,11 +3921,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
           }
         },
         "dateformat": {
@@ -4024,7 +4024,7 @@
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.1"
           }
         },
         "supports-color": {
@@ -4577,7 +4577,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -5518,19 +5518,19 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.5.0",
-            "forever-agent": "0.5.2",
-            "form-data": "0.1.4",
+            "aws-sign2": "~0.5.0",
+            "forever-agent": "~0.5.0",
+            "form-data": "~0.1.0",
             "hawk": "1.1.1",
-            "http-signature": "0.10.1",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "1.0.2",
-            "node-uuid": "1.4.8",
-            "oauth-sign": "0.3.0",
-            "qs": "1.0.2",
-            "stringstream": "0.0.6",
-            "tough-cookie": "2.4.3",
-            "tunnel-agent": "0.4.3"
+            "http-signature": "~0.10.0",
+            "json-stringify-safe": "~5.0.0",
+            "mime-types": "~1.0.1",
+            "node-uuid": "~1.4.0",
+            "oauth-sign": "~0.3.0",
+            "qs": "~1.0.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": ">=0.12.0",
+            "tunnel-agent": "~0.4.0"
           }
         },
         "source-map": {
@@ -5584,11 +5584,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -5609,7 +5609,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -6099,9 +6099,9 @@
           "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
           "dev": true,
           "requires": {
-            "graceful-fs": "2.0.3",
-            "inherits": "2.0.3",
-            "minimatch": "0.2.14"
+            "graceful-fs": "~2.0.0",
+            "inherits": "2",
+            "minimatch": "~0.2.11"
           }
         },
         "graceful-fs": {
@@ -6116,8 +6116,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         },
         "minimist": {
@@ -6661,7 +6661,7 @@
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3"
       }
     },
     "pend": {

--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -110,7 +110,7 @@
         position: relative;
         display: flex;
         align-items: center;
-        justify-content: center;
+        justify-content: flex-end;
         background-color: #f1f8ff;
         border-right: 1px @gray-less solid;
         font-size: 12px;
@@ -125,9 +125,26 @@
         text-overflow: ellipsis;
         white-space: nowrap;
 
-        a {
-          color: @dark-less;
+        .octotree-expand,
+        .octotree-collapse {
+          margin-left: 12px;
+          color: @dark;
           text-decoration: none;
+        }
+
+        .octotree-expand:hover,
+        .octotree-collapse:hover {
+          color: @gray;
+        }
+
+        .octotree-icon-fold {
+          .icon-v2(@octicons-fold, @color: @dark, @hover-color: @gray);
+          vertical-align: middle;
+        }
+
+        .octotree-icon-unfold {
+          .icon-v2(@octicons-unfold, @color: @dark, @hover-color: @gray);
+          vertical-align: middle;
         }
       }
 
@@ -403,7 +420,7 @@
     display: flex;
     flex-flow: row-reverse;
     align-items: center;
-    top: 16px;
+    top: 25px;
     right: 6px;
 
     a {

--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -106,6 +106,31 @@
         }
       }
 
+      .octotree-view-toolbar {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background-color: #f1f8ff;
+        border-right: 1px @gray-less solid;
+        font-size: 12px;
+        font-weight: normal;
+        top: 0;
+        left: 0;
+        line-height: 1;
+        width: 100%;
+        height: @footer-height;
+        padding: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+
+        a {
+          color: @dark-less;
+          text-decoration: none;
+        }
+      }
+
       .octotree-help {
         outline: 0;
         cursor: pointer;

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ $(document).ready(() => {
     const $spinner = $sidebar.find('.octotree-spin');
     const $pinner = $sidebar.find('.octotree-pin');
     const $expander = $sidebar.find('.octotree-expand');
+    const $collapser = $sidebar.find('.octotree-collapse');
     const adapter = new GitHub(store);
     const treeView = new TreeView($dom, store, adapter);
     const optsView = new OptionsView($dom, store, adapter);
@@ -21,7 +22,6 @@ $(document).ready(() => {
     let hasError = false;
 
     $pinner.click(togglePin);
-    $expander.click(toggleFolders);
     setupSidebarFloatingBehaviors();
     setHotkeys(store.get(STORE.HOTKEYS));
 
@@ -30,6 +30,9 @@ $(document).ready(() => {
     $(window).resize((event) => {
       if (event.target === window) layoutChanged();
     });
+
+    $expander.click(() => treeView.$tree.jstree('open_all'));
+    $collapser.click(() => treeView.$tree.jstree('close_all'));
 
     for (const view of [treeView, errorView, optsView]) {
       $(view)
@@ -206,16 +209,6 @@ $(document).ready(() => {
       store.set(STORE.PINNED, sidebarPinned);
       toggleSidebar(sidebarPinned);
       return sidebarPinned;
-    }
-
-    function toggleFolders() {
-      if ($expander.text() === 'Expand All') {
-        treeView.$tree.jstree('open_all');
-        $expander.text('Collapse All');
-      } else if ($expander.text() === 'Collapse All') {
-        treeView.$tree.jstree('close_all');
-        $expander.text('Expand All');
-      }
     }
 
     function layoutChanged(save = false) {

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ $(document).ready(() => {
     const $views = $sidebar.find('.octotree-view');
     const $spinner = $sidebar.find('.octotree-spin');
     const $pinner = $sidebar.find('.octotree-pin');
+    const $expander = $sidebar.find('.octotree-expand');
     const adapter = new GitHub(store);
     const treeView = new TreeView($dom, store, adapter);
     const optsView = new OptionsView($dom, store, adapter);
@@ -20,6 +21,7 @@ $(document).ready(() => {
     let hasError = false;
 
     $pinner.click(togglePin);
+    $expander.click(toggleFolders);
     setupSidebarFloatingBehaviors();
     setHotkeys(store.get(STORE.HOTKEYS));
 
@@ -204,6 +206,16 @@ $(document).ready(() => {
       store.set(STORE.PINNED, sidebarPinned);
       toggleSidebar(sidebarPinned);
       return sidebarPinned;
+    }
+
+    function toggleFolders() {
+      if ($expander.text() === 'Expand All') {
+        treeView.$tree.jstree('open_all');
+        $expander.text('Collapse All');
+      } else if ($expander.text() === 'Collapse All') {
+        treeView.$tree.jstree('close_all');
+        $expander.text('Expand All');
+      }
     }
 
     function layoutChanged(save = false) {

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -38,6 +38,8 @@
 @octicons-file-directory: '\f016';
 @octicons-file-text: '\f011';
 @octicons-file-submodule: '\f017';
+@octicons-fold: '\f0cc';
+@octicons-unfold: '\f039';
 
 // ====== Icons ======
 .icon-v2(@code; @font-family: octicons; @color: @gray; @hover-color: @error; @font-size: 14px; @width: 16px; @top: 0) {

--- a/src/template.html
+++ b/src/template.html
@@ -26,7 +26,14 @@
       <div class="octotree-view octotree-tree-view current">
         <div class="octotree-view-header"></div>
         <div class="octotree-view-toolbar">
-          <a class="octotree-expand">Expand All</a>
+          <div class="octotree-expand">
+            <i class="octotree-icon-unfold"></i>
+            Expand All
+          </div>
+          <div class="octotree-collapse">
+            <i class="octotree-icon-fold"></i>
+            Collapse All
+          </div>
         </div>
         <div class="octotree-view-body"></div>
         <a class="octotree-spin"> <span class="octotree-spin--loader"></span> </a>

--- a/src/template.html
+++ b/src/template.html
@@ -11,12 +11,12 @@
         </div>
       </div>
     </div>
-    
+
     <div class="octotree-main-icons">
       <a class="octotree-pin" data-store="PINNED">
         <span class="tooltipped tooltipped-s" aria-label="Pin this sidebar"> <i class="octotree-icon-pin"></i> </span>
       </a>
-      
+
       <a class="octotree-settings">
         <span class="tooltipped tooltipped-s" aria-label="Settings"> <i class="octotree-icon-settings"></i> </span>
       </a>
@@ -25,6 +25,9 @@
     <div class="octotree-views">
       <div class="octotree-view octotree-tree-view current">
         <div class="octotree-view-header"></div>
+        <div class="octotree-view-toolbar">
+          <a class="octotree-expand">Expand All</a>
+        </div>
         <div class="octotree-view-body"></div>
         <a class="octotree-spin"> <span class="octotree-spin--loader"></span> </a>
       </div>


### PR DESCRIPTION
### Problem
When working with large repos, sometimes it is easier to expand or collapse all folders to navigate to certain file. 

Resolves #774.

### Solution
Adding new feature to expand or collapse all folders in tree. 

I added a toolbar section underneath the header. It is only housing the expand/collapse tool right now but the intention is to allow that space for any future tools too. It can be easily switched to display a row of icons if we wanted to add more to it.

### Screenshots
![Oct-28-2019 16-51-32](https://user-images.githubusercontent.com/10108593/67721247-0f68f400-f9a4-11e9-84dd-24bc19327912.gif)
