### PR TITLE
Center Github main element when sidebar pinned

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -8,6 +8,7 @@ const GH_PJAX_CONTAINER_SEL =
 
 const GH_CONTAINERS = '.container, .container-lg, .container-responsive';
 const GH_HEADER = '.js-header-wrapper > header';
+const GH_MAIN = '#js-repo-pjax-container';
 const GH_MAX_HUGE_REPOS_SIZE = 50;
 const GH_HIDDEN_RESPONSIVE_CLASS = '.d-none';
 const GH_RESPONSIVE_BREAKPOINT = 1010;
@@ -65,6 +66,7 @@ class GitHub extends PjaxAdapter {
   updateLayout(sidebarPinned, sidebarVisible, sidebarWidth) {
     const SPACING = 10;
     const $header = $(GH_HEADER);
+    const $main = $(GH_MAIN);
     const $containers =
       $('html').width() <= GH_RESPONSIVE_BREAKPOINT
         ? $(GH_CONTAINERS).not(GH_HIDDEN_RESPONSIVE_CLASS)
@@ -75,13 +77,15 @@ class GitHub extends PjaxAdapter {
     const smallScreen = autoMarginLeft <= sidebarWidth + SPACING;
 
     $('html').css('margin-left', shouldPushEverything && smallScreen ? sidebarWidth : '');
-    $containers.css('margin-left', shouldPushEverything && smallScreen ? SPACING : '');
+    $containers.css('margin-left', shouldPushEverything && smallScreen ? 'auto' : '');
 
     if (shouldPushEverything && !smallScreen) {
       // Override important in Github Header class in large screen
       $header.attr('style', `padding-left: ${sidebarWidth + SPACING}px !important`);
+      $main.attr('style', `padding-left: ${sidebarWidth + SPACING}px !important`);
     } else {
       $header.removeAttr('style');
+      $main.removeAttr('style');
     }
   }
 


### PR DESCRIPTION
### Problem
The main container of Github was not centred like it's normally be when the sidebar is pinned. I thought it feels weird.

### Solution
I adjust some css attributes to center the main Github view.

### Screenshots
**Before**
![Screen Shot 2019-11-08 at 13 59 37](https://user-images.githubusercontent.com/7858787/68503352-9a61ae00-0230-11ea-9524-6757c5a73e9a.png)
**After**
![Screen Shot 2019-11-08 at 13 59 23](https://user-images.githubusercontent.com/7858787/68503353-9a61ae00-0230-11ea-9762-dbcd58acbd1e.png)
