### PR TITLE
Remove unused constructor parameter from PjaxAdapter

### DIFF
--- a/src/adapters/pjax.js
+++ b/src/adapters/pjax.js
@@ -1,6 +1,6 @@
 class PjaxAdapter extends Adapter {
-  constructor(store) {
-    super(['jquery.pjax.js'], store);
+  constructor() {
+    super(['jquery.pjax.js']);
 
     $(document)
       .on('pjax:start', () => $(document).trigger(EVENT.REQ_START))


### PR DESCRIPTION
### Problem
In #835 the global storage was refactored and the second parameter (`store`) was removed from the `Adapter` class, but not from the `PjaxAdapter`.

### Solution
Remove the `store` parameter from the `PjaxAdapter` class.