### PR TITLE
Dispatch `pjax:end` event on native `document`

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -13,10 +13,13 @@ const GH_HIDDEN_RESPONSIVE_CLASS = '.d-none';
 const GH_RESPONSIVE_BREAKPOINT = 1010;
 
 class GitHub extends PjaxAdapter {
+  constructor() {
+    super(GH_PJAX_CONTAINER_SEL);
+  }
+
   // @override
   init($sidebar) {
-    const pjaxContainer = $(GH_PJAX_CONTAINER_SEL)[0];
-    super.init($sidebar, {pjaxContainer: pjaxContainer});
+    super.init($sidebar);
 
     // Fix #151 by detecting when page layout is updated.
     // In this case, split-diff page has a wider layout, so need to recompute margin.
@@ -171,11 +174,6 @@ class GitHub extends PjaxAdapter {
         cb(null, repo);
       });
     }
-  }
-
-  // @override
-  selectFile(path) {
-    super.selectFile(path, {pjaxContainerSel: GH_PJAX_CONTAINER_SEL});
   }
 
   // @override

--- a/src/adapters/pjax.js
+++ b/src/adapters/pjax.js
@@ -1,6 +1,7 @@
 class PjaxAdapter extends Adapter {
-  constructor(store) {
-    super(['jquery.pjax.js'], store);
+  constructor(pjaxContainerSel) {
+    super(['jquery.pjax.js']);
+    this._pjaxContainerSel = pjaxContainerSel;
 
     $(document)
       .on('pjax:start', () => $(document).trigger(EVENT.REQ_START))
@@ -9,13 +10,11 @@ class PjaxAdapter extends Adapter {
   }
 
   // @override
-  // @param {Object} opts - {pjaxContainer: the specified pjax container}
   // @api public
-  init($sidebar, opts) {
+  init($sidebar) {
     super.init($sidebar);
 
-    opts = opts || {};
-    const pjaxContainer = opts.pjaxContainer;
+    const pjaxContainer = $(this._pjaxContainerSel)[0];
 
     if (!window.MutationObserver) return;
 
@@ -60,11 +59,8 @@ class PjaxAdapter extends Adapter {
   }
 
   // @override
-  // @param {Object} opts - {$pjax_container: jQuery object}
   // @api public
-  selectFile(path, opts) {
-    opts = opts || {};
-
+  selectFile(path) {
     // Do nothing if file is already selected.
     if (location.pathname === path) return;
 
@@ -72,15 +68,14 @@ class PjaxAdapter extends Adapter {
     // Don't bother fetching the page with pjax
     const pathWithoutAnchor = path.replace(/#.*$/, '');
     const isSamePage = location.pathname === pathWithoutAnchor;
-    const pjaxContainerSel = opts.pjaxContainerSel;
-    const loadWithPjax = $(pjaxContainerSel).length && !isSamePage;
+    const loadWithPjax = $(this._pjaxContainerSel).length && !isSamePage;
 
     if (loadWithPjax) {
       this._patchPjax();
       $.pjax({
         // Needs full path for pjax to work with Firefox as per cross-domain-content setting
         url: location.protocol + '//' + location.host + path,
-        container: pjaxContainerSel,
+        container: this._pjaxContainerSel,
         timeout: 0 // global timeout doesn't seem to work, use this instead
       });
     } else {


### PR DESCRIPTION
### Problem
GitHub's own pjax implementation dispatches its events directly in the DOM, while the jQuery pjax library we use here dispatches its events only within its jQuery instance. 

Because some GitHub add-ons listen to certain pjax events in the DOM it may be necessary to forward an event from jQuery to the DOM to make sure those add-ons don't break. 

Fixes #490 

### Solution
Dispatch the `pjax:start` and `pjax:end` events (for now) in the native DOM whenever they're dispatched within jQuery.

_Note that I don't forward the event details/extra parameters or whether they're cancellable at the moment, because the pjax implementations differ in this case and I could not find a case where this info is used by listeners._

### Screenshots
Before this PR when navigating through Octotree:
![grafik](https://user-images.githubusercontent.com/424602/71551147-3feaff80-29e0-11ea-9e9a-b24e1f3f5cce.png)

After the PR or when navigating though GitHub or reloading the page manually:
![grafik](https://user-images.githubusercontent.com/424602/71551157-98220180-29e0-11ea-901f-539fcce10b6c.png)

As can be seen on the second screenshot, Refined GitHub adds gray dots to show the whitespace and OctoLinker adds pink dots to indicate that you can navigate to the required libraries.

---

As I have no experience in browser add-on development and there's no documentation how I could build and install my local Octotree development version in my Firefox, I don't know how to verify if the solution is working. But I've done a lot of research and digging through (minified) JavaScript and am therefore pretty confident it does.

So, could you please verify this?