### PR TITLE
Fix layout on New PR page

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -7,7 +7,6 @@ const GH_PJAX_CONTAINER_SEL =
   '#js-repo-pjax-container, div[itemtype="http://schema.org/SoftwareSourceCode"] main, [data-pjax-container]';
 
 const GH_CONTAINERS = '.container, .container-lg, .container-responsive';
-const GH_HEADER = '.js-header-wrapper > header';
 const GH_MAX_HUGE_REPOS_SIZE = 50;
 const GH_HIDDEN_RESPONSIVE_CLASS = '.d-none';
 const GH_RESPONSIVE_BREAKPOINT = 1010;
@@ -78,7 +77,6 @@ class GitHub extends PjaxAdapter {
   // @override
   updateLayout(sidebarPinned, sidebarVisible, sidebarWidth) {
     const SPACING = 10;
-    const $header = $(GH_HEADER);
     const $containers =
       $('html').width() <= GH_RESPONSIVE_BREAKPOINT
         ? $(GH_CONTAINERS).not(GH_HIDDEN_RESPONSIVE_CLASS)
@@ -86,17 +84,9 @@ class GitHub extends PjaxAdapter {
 
     const autoMarginLeft = ($(document).width() - $containers.width()) / 2;
     const shouldPushEverything = sidebarPinned && sidebarVisible;
-    const smallScreen = autoMarginLeft <= sidebarWidth + SPACING;
 
-    $('html').css('margin-left', shouldPushEverything && smallScreen ? sidebarWidth : '');
-    $containers.css('margin-left', shouldPushEverything && smallScreen ? SPACING : '');
-
-    if (shouldPushEverything && !smallScreen) {
-      // Override important in Github Header class in large screen
-      $header.attr('style', `padding-left: ${sidebarWidth + SPACING}px !important`);
-    } else {
-      $header.removeAttr('style');
-    }
+    $('html').css('margin-left', shouldPushEverything ? sidebarWidth : '');
+    $containers.css('margin-left', shouldPushEverything ? Math.max(SPACING, autoMarginLeft - sidebarWidth) : '');
   }
 
   // @override


### PR DESCRIPTION
### Problem
On create new PR page, octotree sidebar overlay the changed files section even when the sidebar is pinned

### Solution
Change `adapter.updateLayout` behavior

### Screenshots
Before
![image](https://user-images.githubusercontent.com/28825116/71640650-95fdc280-2cc0-11ea-80f3-84ec0aa02e28.png)
After
![updateLayout_2](https://user-images.githubusercontent.com/28825116/71640654-add54680-2cc0-11ea-8cc0-7b59326419c7.gif)

