### PR TITLE
Fix: Tree icons stretch in Firefox

### DIFF
--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -223,7 +223,7 @@
 
         .jstree-icon {
           width: 16px;
-          flex-shrink: 0;
+          flex: 0 0 auto;
         }
 
         .jstree-icon,


### PR DESCRIPTION
### Problem

The icons in the tree are stretched, thus the whole tree looks weird.

![image](https://user-images.githubusercontent.com/4380869/71657464-3ba44680-2d40-11ea-9130-3e7cb779369c.png)

### Solution
Change `flex` property of icon to prevent stretching.

Result:
![image](https://user-images.githubusercontent.com/4380869/71657506-6ee6d580-2d40-11ea-9862-d4039804850c.png)

### Platform Info
- Octotree Version 4.1.3
- Firefox 71 (64bit) on Windows 10
