### PR TITLE
Fix content jumps right if sidebar is pinned

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -76,17 +76,28 @@ class GitHub extends PjaxAdapter {
 
   // @override
   updateLayout(sidebarPinned, sidebarVisible, sidebarWidth) {
-    const SPACING = 10;
+    const SPACING = 20;
     const $containers =
       $('html').width() <= GH_RESPONSIVE_BREAKPOINT
         ? $(GH_CONTAINERS).not(GH_HIDDEN_RESPONSIVE_CLASS)
         : $(GH_CONTAINERS);
 
-    const autoMarginLeft = ($(document).width() - $containers.width()) / 2;
     const shouldPushEverything = sidebarPinned && sidebarVisible;
+        
+    if (shouldPushEverything) {
+      $('html').css('margin-left', sidebarWidth);
 
-    $('html').css('margin-left', shouldPushEverything ? sidebarWidth : '');
-    $containers.css('margin-left', shouldPushEverything ? Math.max(SPACING, autoMarginLeft - sidebarWidth) : '');
+      const autoMarginLeft = ($(document).width() - $containers.width()) / 2;
+      const marginLeft = Math.max(SPACING, autoMarginLeft - sidebarWidth);
+      $containers.each(function () {
+        const $container = $(this);
+        const paddingLeft = ($container.innerWidth() - $container.width()) / 2;
+        $container.css('margin-left', marginLeft - paddingLeft);
+      })
+    } else {
+      $('html').css('margin-left', '');
+      $containers.css('margin-left', '');
+    }
   }
 
   // @override


### PR DESCRIPTION
### Problem
Due to #865  when pin, the content jumps right

### Solution
Add padding to the caculation of margin-left of the content

### Screenshots
Before #865
The content only jumps right when the sidebar is pinned and its width is big enough
![a](https://user-images.githubusercontent.com/28825116/71709530-3d4a3900-2e2a-11ea-860f-d2819c8a95a6.gif)

After #865
The content jumps right when the sidebar is pinned
![a](https://user-images.githubusercontent.com/28825116/71709407-7cc45580-2e29-11ea-92ef-3c565eae1da3.gif)

After this
The content never jumps right
![a](https://user-images.githubusercontent.com/28825116/71709484-fbb98e00-2e29-11ea-87c2-c2a7d4a15eff.gif)

