### PR TITLE
Fix layout when sidebar is pinned

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -7,7 +7,6 @@ const GH_PJAX_CONTAINER_SEL =
   '#js-repo-pjax-container, div[itemtype="http://schema.org/SoftwareSourceCode"] main, [data-pjax-container]';
 
 const GH_CONTAINERS = '.container, .container-lg, .container-responsive';
-const GH_HEADER = '.js-header-wrapper > header';
 const GH_MAX_HUGE_REPOS_SIZE = 50;
 const GH_HIDDEN_RESPONSIVE_CLASS = '.d-none';
 const GH_RESPONSIVE_BREAKPOINT = 1010;
@@ -77,25 +76,27 @@ class GitHub extends PjaxAdapter {
 
   // @override
   updateLayout(sidebarPinned, sidebarVisible, sidebarWidth) {
-    const SPACING = 10;
-    const $header = $(GH_HEADER);
+    const SPACING = 20;
     const $containers =
       $('html').width() <= GH_RESPONSIVE_BREAKPOINT
         ? $(GH_CONTAINERS).not(GH_HIDDEN_RESPONSIVE_CLASS)
         : $(GH_CONTAINERS);
 
-    const autoMarginLeft = ($(document).width() - $containers.width()) / 2;
     const shouldPushEverything = sidebarPinned && sidebarVisible;
-    const smallScreen = autoMarginLeft <= sidebarWidth + SPACING;
 
-    $('html').css('margin-left', shouldPushEverything && smallScreen ? sidebarWidth : '');
-    $containers.css('margin-left', shouldPushEverything && smallScreen ? SPACING : '');
+    if (shouldPushEverything) {
+      $('html').css('margin-left', sidebarWidth);
 
-    if (shouldPushEverything && !smallScreen) {
-      // Override important in Github Header class in large screen
-      $header.attr('style', `padding-left: ${sidebarWidth + SPACING}px !important`);
+      const autoMarginLeft = ($(document).width() - $containers.width()) / 2;
+      const marginLeft = Math.max(SPACING, autoMarginLeft - sidebarWidth);
+      $containers.each(function () {
+        const $container = $(this);
+        const paddingLeft = ($container.innerWidth() - $container.width()) / 2;
+        $container.css('margin-left', marginLeft - paddingLeft);
+      })
     } else {
-      $header.removeAttr('style');
+      $('html').css('margin-left', '');
+      $containers.css('margin-left', '');
     }
   }
 


### PR DESCRIPTION
### Problem
When the octotree sidebar is pinned
- On create new PR page, it overlays the changed files section
- The page content got pushed to the right by 16px

### Solution
Change `adapter.updateLayout` behavior, to:
- Always set margin-left for the whole page so that no elements will ever be overlayed
- Caculate the proper margin-left of the page's content to keep it at as near to its intial position as possible without pushing it to the right

### Screenshots
Before
![image](https://user-images.githubusercontent.com/28825116/71640650-95fdc280-2cc0-11ea-80f3-84ec0aa02e28.png)
![image](https://user-images.githubusercontent.com/28825116/71718575-36cdb880-2e4e-11ea-865b-f8e4f091cb6f.png)

After
![a](https://user-images.githubusercontent.com/28825116/71718657-81e7cb80-2e4e-11ea-97f1-723ab903b238.gif)
