### PR TITLE
fix optsView toggler state

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -35,6 +35,8 @@ $(document).ready(() => {
           if (this !== optsView) {
             $document.trigger(EVENT.REQ_END);
 
+            optsView.$toggler.removeClass('selected');
+
             if (adapter.isOnPRPage && await extStore.get(STORE.PR)) {
               treeView.$tree.jstree('open_all');
             }


### PR DESCRIPTION
### Problem
This PR is to fix the recently merged #869 
Steps to produce:
Open 2 tabs, go to Settings in both tabs, change a setting in one tab and save -> the other tab is updated and shows the tree, but the Settings icon is still highlighted.

### Solution
Force the toggler to remove it's active state when a different view is shown