### PR TITLE
Fix layout on New PR page

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -76,7 +76,6 @@ class GitHub extends PjaxAdapter {
 
   // @override
   updateLayout(sidebarPinned, sidebarVisible, sidebarWidth) {
-    const SPACING = 20;
     const $containers =
       $('html').width() <= GH_RESPONSIVE_BREAKPOINT
         ? $(GH_CONTAINERS).not(GH_HIDDEN_RESPONSIVE_CLASS)
@@ -88,12 +87,11 @@ class GitHub extends PjaxAdapter {
       $('html').css('margin-left', sidebarWidth);
 
       const autoMarginLeft = ($(document).width() - $containers.width()) / 2;
-      const marginLeft = Math.max(SPACING, autoMarginLeft - sidebarWidth);
+      const marginLeft = Math.max(0, autoMarginLeft - sidebarWidth);
       $containers.each(function () {
         const $container = $(this);
-        const paddingLeft = ($container.innerWidth() - $container.width()) / 2;
-        $container.css('margin-left', marginLeft - paddingLeft);
-      })
+        $container.css('margin-left', marginLeft);
+      });
     } else {
       $('html').css('margin-left', '');
       $containers.css('margin-left', '');

--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -89,10 +89,7 @@ class GitHub extends PjaxAdapter {
 
       const autoMarginLeft = ($(document).width() - $containers.width()) / 2;
       const marginLeft = Math.max(0, autoMarginLeft - sidebarWidth);
-      $containers.each(function () {
-        const $container = $(this);
-        $container.css('margin-left', marginLeft);
-      });
+      $containers.css('margin-left', marginLeft);
     } else {
       $('html').css('margin-left', '');
       $containers.css('margin-left', '');


### PR DESCRIPTION
### Problem
On create new PR page, octotree sidebar overlay the changed files section even when the sidebar is pinned

### Solution
Change `adapter.updateLayout` behavior

### Screenshots
Before
![image](https://user-images.githubusercontent.com/28825116/71640650-95fdc280-2cc0-11ea-80f3-84ec0aa02e28.png)
After
![updateLayout_2](https://user-images.githubusercontent.com/28825116/71640654-add54680-2cc0-11ea-8cc0-7b59326419c7.gif)
