### PR TITLE
fix PR navigation

### DIFF
--- a/src/adapters/adapter.js
+++ b/src/adapters/adapter.js
@@ -272,9 +272,10 @@ class Adapter {
       // Smooth scroll to diff file on PR page
       const diffMatch = path.match(/#diff-\d+$/);
       if (diffMatch) {
-        const el = $(diffMatch[0]);
-        if (el.length > 0) {
-          $('html, body').animate({scrollTop: el.offset().top - 68}, 400);
+        const diffNumber = +path.split('-').slice(-1)[0] + 1;
+        const $el = $(`#files .file:nth-of-type(${diffNumber})`);
+        if ($el.length) {
+          $('html, body').animate({scrollTop: $el.offset().top - 68}, 400);
           return;
         }
       }


### PR DESCRIPTION
### Problem
Can't navigate to files, GitHub probably has changed something

### Solution
The best solution would be to change the href of the file in the tree to be same as the id of the diff in the page. But i couldn't find that hash string anywhere. 
So my approach is to select the diff in the page by its order.

