### PR TITLE
Fix broken navigation on PR /files page

### DIFF
--- a/src/adapters/adapter.js
+++ b/src/adapters/adapter.js
@@ -89,7 +89,7 @@ class Adapter {
               }
 
               // If item is part of a PR, jump to that file's diff
-              if (item.patch && typeof item.patch.diffId === 'number') {
+              if (item.patch && item.patch.diffId) {
                 const url = this._getPatchHref(repo, item.patch);
                 item.a_attr = {
                   href: url,
@@ -270,7 +270,7 @@ class Adapter {
   selectFile(path) {
     if (!isSafari()) {
       // Smooth scroll to diff file on PR page
-      const diffMatch = path.match(/#diff-\d+$/);
+      const diffMatch = path.match(/#diff-.+$/);
       if (diffMatch) {
         const el = $(diffMatch[0]);
         if (el.length > 0) {


### PR DESCRIPTION
### Problem
Github PR files page recently changed. This breaks the navigation on the sidebar's tree

### Solution
The cause/change that GH made was adding an explicit id to each diff section of the page.
I couldn't find these ids on the API doc.
So the solution is to fetch the whole /files page and extract those ids from the returned html
