### PR TITLE
Replace raw file path on tree file to edit path

### DIFF
--- a/src/adapters/adapter.js
+++ b/src/adapters/adapter.js
@@ -273,27 +273,6 @@ class Adapter {
   }
 
   /**
-   * Downloads a file.
-   * @api public
-   */
-  downloadFile(path, fileName) {
-    const downloadUrl = path.replace(/\/blob\/|\/src\//, '/raw/');
-    const link = document.createElement('a');
-
-    link.setAttribute('href', downloadUrl);
-
-    // Github will redirect to a different origin (host) for downloading the file.
-    // However, the new host hasn't been added in the Content-Security-Policy header from
-    // Github so the browser won't save the file, it navigates to the file instead.
-    // Using '_blank' as a trick to not being navigated
-    // See more about Content Security Policy at
-    // https://www.html5rocks.com/en/tutorials/security/content-security-policy/
-    link.setAttribute('target', '_blank');
-
-    link.click();
-  }
-
-  /**
    * Gets tree at path.
    * @param {Object} opts - {token, repo}
    * @api protected

--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -279,7 +279,7 @@
       }
 
       .jstree-node.jstree-leaf:hover .jstree-icon.blob {
-        .icon-v2(@octicons-link-external, @color: @error, @hover-color: @error, @font-size: 15px);
+        .icon-v2(@octicons-pencil, @color: @error, @hover-color: @error, @font-size: 15px);
       }
     }
 

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -38,6 +38,7 @@
 @octicons-file-directory: '\f016';
 @octicons-file-text: '\f011';
 @octicons-file-submodule: '\f017';
+@octicons-pencil: "\f058";
 
 // ====== Icons ======
 .icon-v2(@code; @font-family: octicons; @color: @gray; @hover-color: @error; @font-size: 14px; @width: 16px; @top: 0) {

--- a/src/view.tree.js
+++ b/src/view.tree.js
@@ -125,11 +125,10 @@ class TreeView {
       refocusAfterCompletion();
       newTab ? adapter.openInNewTab(href) : adapter.selectSubmodule(href);
     } else if ($icon.hasClass('blob')) {
-      const download = $(event.target).is('i.jstree-icon');
-      if (download) {
-        const downloadUrl = $target.attr('data-download-url');
-        const downloadFileName = $target.attr('data-download-filename');
-        adapter.downloadFile(downloadUrl, downloadFileName);
+      const isIconClicked = $(event.target).is('i.jstree-icon');
+      if (isIconClicked) {
+        const editUrl = $target.attr('data-download-url').replace(/\/blob\/|\/src\//, '/edit/');
+        adapter.selectFile(editUrl);
       } else {
         refocusAfterCompletion();
         newTab ? adapter.openInNewTab(href) : adapter.selectFile(href);


### PR DESCRIPTION
This PR is to replace the raw download path on the tree file into an edit path.

Few points i want to address before merging this : 

- Should we remove the lines from 279 till 294 in adapter.js ? as they are useless and are not used anywhere in codebase now https://github.com/ovity/octotree/blob/master/src/adapters/adapter.js#L279
- Current behavior is to navigate into the edit page without opening new tab, is that okay ? 

Screenshots on how the icon looks like when hovering over file path :

![Screen Shot 2020-04-14 at 2 50 09 PM](https://user-images.githubusercontent.com/10753722/79221897-4c944600-7e5f-11ea-9c9a-883d3ac57a09.png)
