### PR TITLE
Fix scroll in settings view

### DIFF
--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -289,6 +289,10 @@
         padding-left: 8px;
       }
       .octotree-view-body {
+        height: 100%;
+        overflow-x: hidden;
+        overflow-y: auto;
+
         input[type="checkbox"], input[type="radio"] {
           vertical-align: middle;
         }

--- a/src/template.html
+++ b/src/template.html
@@ -52,7 +52,7 @@
                 target="_blank"
                 tabindex="-1"
               >
-                <span class="tooltipped tooltipped-n" aria-label="Learn more">
+                <span class="tooltipped tooltipped-w" aria-label="Learn more">
                   <i class="octotree-icon-help"></i>
                 </span>
               </a>
@@ -66,7 +66,7 @@
               <label>Hotkeys</label>
               <div class="octotree-token-actions">
                 <a class="octotree-help" href="https://github.com/ovity/octotree#hotkeys" target="_blank" tabindex="-1">
-                  <span class="tooltipped tooltipped-n" aria-label="Learn more">
+                  <span class="tooltipped tooltipped-w" aria-label="Learn more">
                     <i class="octotree-icon-help"></i>
                   </span>
                 </a>


### PR DESCRIPTION
### Problem
Fix https://github.com/ovity/octotree/issues/904

### Solution
The last PR #906 was closed because that fix cause the tooltips to be cut off.
So the solution is having the tooltip display on the left side, no more overflow and being cut off

### Screenshots
![image](https://user-images.githubusercontent.com/28825116/79684154-6d8ed980-8259-11ea-8970-057db3403a8e.png)
