### PR TITLE
fix: don't render on sponsors pages

### DIFF
--- a/src/core.api.js
+++ b/src/core.api.js
@@ -29,6 +29,7 @@ const GH_RESERVED_USER_NAMES = [
   'settings',
   'showcases',
   'site',
+  'sponsors',
   'stars',
   'styleguide',
   'topics',


### PR DESCRIPTION
### Problem
Octotree renders on Sponsors pages, which are not repos.

### Solution
Add sponsors to list of reserved names.

### Screenshots
Before:
![2020-04-22-123023_415x263_scrot](https://user-images.githubusercontent.com/12520493/80019664-6836c680-84c7-11ea-988d-075d859a24c4.png)

I don't have an after screenshot because this is using Gulp 3, and I'm on Node 13: https://github.com/gulpjs/gulp/issues/2324 so I can't build and test.

