### PR TITLE
fix: fix header height error at large layout

### DIFF
--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -8,6 +8,9 @@
   overflow: visible;
   padding-bottom: @footer-height;
   padding-top: @header-height;
+  @media all and (min-width: @lg-width) {
+    padding-top: @lg-header-height;
+  }
   position: fixed;
   transform: translate3d(-100%, 0, 0);
   transition: transform 0.3s ease-in;
@@ -95,6 +98,9 @@
         line-height: 1;
         width: 100%;
         height: @header-height;
+        @media all and (min-width: @lg-width) {
+          height: @lg-header-height;
+        }
         margin: 0;
         padding-right: 65px;
         overflow: hidden;

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -1,3 +1,6 @@
+// ====== Layout ======
+@lg-width: 1012px;
+
 // ====== Colors ======
 @red: #e93838;
 @dark: #0f2e47;
@@ -17,6 +20,7 @@
 
 // ====== Sizing ======
 @header-height: 64px;
+@lg-header-height: 53px;
 @footer-height: 30px;
 @icon-size: 16px;
 


### PR DESCRIPTION
### Problem

When the screen width bigger than 1012px, height of header is wrong.

### Solution

Add new variable and media query to solve the problem.

### Screenshots

**Before**

![image](https://user-images.githubusercontent.com/18362949/80122223-d5c61e00-85bf-11ea-9c63-444025d6521d.png)

**After**

![image](https://user-images.githubusercontent.com/18362949/80122876-b7145700-85c0-11ea-8de4-31e18656e5f9.png)
