### PR TITLE
Minor UI changes

### DIFF
--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -377,7 +377,7 @@
     display: flex;
     flex-flow: row-reverse;
     align-items: center;
-    top: 16px;
+    top: 10px;
     right: 6px;
 
     a {


### PR DESCRIPTION
fixes https://github.com/ovity/octotree/pull/932

After the mentioned PR some of the main header icons are not aligned probably this is a follow up PR to fix it.

Screenshots:

![Screen Shot 2020-05-03 at 3 58 19 PM](https://user-images.githubusercontent.com/10753722/80914835-f0825a80-8d56-11ea-930c-88c08d3accea.png)
