### PR TITLE
Fix sidebar toggling in error tabs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -131,9 +131,6 @@ $(document).ready(() => {
         if (err) {
           // Error making API, likely private repo but no token
           await showError(err);
-          if (!isSidebarVisible()) {
-            $toggler.show();
-          }
         } else if (repo) {
           if (await extStore.get(STORE.PINNED) && !isSidebarVisible()) {
             // If we're in pin mode but sidebar doesn't show yet, show it.
@@ -174,7 +171,12 @@ $(document).ready(() => {
       hasError = true;
       errorView.show(err);
 
-      if (await extStore.get(STORE.PINNED)) await togglePin(true);
+      if (await extStore.get(STORE.PINNED) && !isSidebarVisible()) {
+        if (isSidebarPinned()) await toggleSidebar();
+        else await onPinToggled(true);
+      } else {
+        $toggler.show();
+      }
     }
 
     async function toggleSidebar(visibility) {

--- a/src/main.js
+++ b/src/main.js
@@ -177,6 +177,8 @@ $(document).ready(() => {
       } else {
         $toggler.show();
       }
+
+      return;
     }
 
     async function toggleSidebar(visibility) {


### PR DESCRIPTION
When API limit exceeded is shown sidebar won't toggle in :
- Issue page
- PR list page

Solution is by duplicating :
https://github.com/ovity/octotree/blob/master/src/main.js#L141 to https://github.com/ovity/octotree/blob/master/src/main.js#L142

inside the ```showError``` method
https://github.com/ovity/octotree/blob/master/src/main.js#L173
 