### PR TITLE
Better icon match for Codecov

### DIFF
--- a/libs/file-icons.js
+++ b/libs/file-icons.js
@@ -341,7 +341,7 @@
     ["chartjs-icon",["dark-pink","dark-pink"],/^Chart\.js$/i,2],
     ["circleci-icon",["medium-green","medium-green"],/^circle\.yml$/i,2],
     ["cc-icon",["medium-green","medium-green"],/\.codeclimate\.yml$/i,2],
-    ["codecov-icon",["dark-pink","dark-pink"],/^codecov\.ya?ml$/i,2],
+    ["codecov-icon",["dark-pink","dark-pink"],/^\.?codecov\.ya?ml$/i,2],
     ["coffee-icon",["medium-cyan","medium-cyan"],/\.coffee\.ecr$/i,2],
     ["coffee-icon",["medium-red","medium-red"],/\.coffee\.erb$/i,2],
     ["compass-icon",["medium-red","medium-red"],/^_?(?:compass|lemonade)\.scss$/i,2],


### PR DESCRIPTION
### Problem

Icon of Codecov configuration file `.codecov.yml` appears to be the icon for a generic YAML file instead of Codecov's, for octotree only matches `codecov.y(a)ml` but not `.codecov.y(a)ml`.

Codecov permits both names, as said in [the official documentation](https://docs.codecov.io/docs/codecov-yaml#can-i-name-the-file-codecovyml):

> **Can I name the file .codecov.yml?**
> Yes. However, the file must still be located in the root, `dev/`, or `.github/` directories

### Solution
Update the icon database so that octotree can associate both names with Codecov.

### Screenshots

Before:
![before](https://user-images.githubusercontent.com/19173506/84010426-327e6c00-a9a7-11ea-92bf-2425711fdd91.png)

After:
![after](https://user-images.githubusercontent.com/19173506/84010456-3f02c480-a9a7-11ea-8d14-7622f6a0561e.png)
