### PR TITLE
Fix noti disappear on PR page

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -88,7 +88,9 @@ class GitHub extends PjaxAdapter {
       const htmlMarginLeft = Math.min(sidebarWidth, Math.max(0, sidebarWidth - autoMarginLeft + SPACING) * 2);
       const fullWidthsPaddingLeft = Math.max(0, sidebarWidth - htmlMarginLeft + SPACING);
 
-      $fullWidthContainers.css(paddingSide, `${fullWidthsPaddingLeft}px`);
+      $fullWidthContainers.each(function () {
+        this.style.setProperty(paddingSide, `${fullWidthsPaddingLeft}px`, 'important');
+      })
       $html.css(marginSide, `${htmlMarginLeft}px`);
     } else {
       $fullWidthContainers.css(paddingSide, '');

--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -76,6 +76,8 @@ class GitHub extends PjaxAdapter {
     const $fullWidthContainers = $(GH_FULL_WIDTH_CONTAINERS);
     const $html = $('html');
     const dockSide = this.getDockSide();
+    const paddingSide = `padding-${dockSide}`;
+    const marginSide = `margin-${dockSide}`;
 
     if (sidebarPinned && sidebarVisible) {
       const screenWidth = $(window).width();
@@ -86,11 +88,11 @@ class GitHub extends PjaxAdapter {
       const htmlMarginLeft = Math.min(sidebarWidth, Math.max(0, sidebarWidth - autoMarginLeft + SPACING) * 2);
       const fullWidthsPaddingLeft = Math.max(0, sidebarWidth - htmlMarginLeft + SPACING);
 
-      $fullWidthContainers.attr('style', `padding-${dockSide}: ${fullWidthsPaddingLeft}px !important`);
-      $html.css(`margin-${dockSide}`, `${htmlMarginLeft}px`);
+      $fullWidthContainers.css(paddingSide, `${fullWidthsPaddingLeft}px`);
+      $html.css(marginSide, `${htmlMarginLeft}px`);
     } else {
-      $fullWidthContainers.removeAttr('style');
-      $html.css(`margin-${dockSide}`, '');
+      $fullWidthContainers.css(paddingSide, '');
+      $html.css(marginSide, '');
     }
   }
 
@@ -157,13 +159,13 @@ class GitHub extends PjaxAdapter {
       // The above should work for tree|blob, but if DOM changes, fallback to use ID from URL
       ((type === 'tree' || type === 'blob') && typeId) ||
       // Use target branch in a PR page
-      (isPR ? ($('.commit-ref').not('.head-ref').attr('title') || ':').match(/:(.*)/)[1] : null) ||
+      (isPR ? ($('.commit-ref:not(.head-ref) a').attr('title') || ':').match(/:(.*)/)[1] : null) ||
       // Reuse last selected branch if exist
       (currentRepo.username === username && currentRepo.reponame === reponame && currentRepo.branch) ||
       // Get default branch from cache
       this._defaultBranch[username + '/' + reponame];
 
-    const pullHead = isPR ? ($('.commit-ref.head-ref').attr('title') || ':').match(/:(.*)/)[1] : null;
+    const pullHead = isPR ? ($('.commit-ref.head-ref a').attr('title') || ':').match(/:(.*)/)[1] : null;
     const pullNumber = isPR ? typeId : null;
     const displayBranch = isPR && pullHead ? `${branch} < ${pullHead}` : null;
     const repo = {username, reponame, branch, displayBranch, pullNumber};


### PR DESCRIPTION
### Problem
- go to https://github.com/notifications. Click any issue (also try pull request) in the big list in the center. Scroll -> notification bar disappear
- On PR page related to deleted branches, octotree crash

### Solution
- notification bar disappear: set css explicity instead of overwriting all of elements's style which caused the loss of style position: sticky of notification bar
- Octotree crash: Unhandeled case when there is a deleted branche related to the PR

