### PR TITLE
Add readme to GH_RESERVED_USER_NAMES

### DIFF
--- a/src/core.api.js
+++ b/src/core.api.js
@@ -23,6 +23,7 @@ const GH_RESERVED_USER_NAMES = [
   'personal',
   'pricing',
   'pulls',
+  'readme',
   'search',
   'security',
   'sessions',


### PR DESCRIPTION
### Problem
Octotree appears on readme pages.
Example pages:
https://github.com/readme/caleb-porzio
https://github.com/readme/safia-abdalla

### Solution
add `readme` to `GH_RESERVED_USER_NAMES`.

### Screenshots
Screenshots before and after applying the PR.
